### PR TITLE
Automatically add issue to project board

### DIFF
--- a/.github/workflows/add_issue_to_project.yml
+++ b/.github/workflows/add_issue_to_project.yml
@@ -1,0 +1,18 @@
+name: Add issue to project board
+# This action could be removed when editing workflow project feature will be enabled.
+# Still notify with "Coming soon" flag.
+# Until now, that's not possible to specify a column, see https://github.com/actions/add-to-project/issues/71
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/epinio/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Add a github action to automatically assign issue to Epinio planning project.
If issue's author forgets to assign to the project, it will be done automatically.