### PR TITLE
Add workflow to build epinio extension helm repo for Rancher

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,74 @@
+name: Build and release container to registry
+
+on:
+  # This workflow won't work until the publish script `BASE_EXT=$(basename ${BASE_DIR})` is fixed (expects repo name, but out case gets `dashboard`)
+  # push:
+  #   branches:
+  #     - main
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./dashboard
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  # should match default `working-directory`
+  APP_ROOT: ./dashboard
+
+jobs:
+  build:
+    name: Build container image
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions: write-all
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Configure Git
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.8.0
+
+      - name: Setup yq
+        uses: chrisdickinson/setup-yq@v1.0.1
+        with:
+          yq-version: v4.28.2
+
+      - name: Setup Nodejs and npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Setup yarn
+        run: npm install -g yarn
+
+      - name: Setup Nodejs with yarn caching
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: yarn
+          cache-dependency-path: '${{ env.APP_ROOT }}/yarn.lock'
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build and push UI image
+        run: |
+          yarn publish-pkgs -cp -r ${{ env.REGISTRY }} -o ${{ github.repository_owner }} -i "ui-extension-epinio-"

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,0 +1,131 @@
+name: Build and Release Extension
+
+on:
+  push:
+    branches:
+      # TODO: RC
+      - package-helm
+  pull_request:
+    branches:
+      # TODO: RC
+      - package-helm
+  workflow_dispatch:
+
+
+defaults:
+  run:
+    shell: bash
+    # TODO: RC
+    working-directory: ./dashboard
+
+env:
+  ACTIONS_RUNNER_DEBUG: true
+  CI_COMMIT_MESSAGE: CI Build Artifacts
+  # should match branches from `on` triggers
+  DEFAULT_BRANCH: package-helm
+  # should match default `working-directory`
+  APP_ROOT: ./dashboard
+
+jobs:
+  build:
+    name: Build extension artifact
+    runs-on: ubuntu-latest
+    permissions: write-all
+    outputs:
+      SHOULD_RELEASE: ${{ steps.should-release.outputs.SHOULD_RELEASE }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.8.0
+
+      - name: Setup yq
+        uses: chrisdickinson/setup-yq@v1.0.1
+        with:
+          yq-version: v4.28.2
+
+      - name: Setup Nodejs and npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Setup yarn
+        run: npm install -g yarn
+
+      - name: Setup Nodejs with yarn caching
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: yarn
+          cache-dependency-path: '${{ env.APP_ROOT }}/yarn.lock'
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Run build script
+        shell: bash
+        id: build_script
+        run: |
+          yarn publish-pkgs -s "${{ github.repository }}" -b gh-pages
+
+      - name: Upload charts artifact
+        if: github.ref == 'refs/heads/${{ env.DEFAULT_BRANCH }}' && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v3
+        with:
+          name: charts
+          path: ${{ env.APP_ROOT }}/tmp
+
+      - name: Should Release
+        id: should-release
+        if: github.ref == 'refs/heads/${{ env.DEFAULT_BRANCH }}' && github.event_name != 'pull_request'
+        run: |
+          echo "SHOULD_RELEASE=true" >> "$GITHUB_OUTPUT"
+
+  release:
+    name: Release Build
+    if: needs.build.outputs.SHOULD_RELEASE == 'true' && github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: charts
+          path: ${{ env.APP_ROOT }}
+
+      - name: Commit build
+        working-directory: ./
+        run: |
+          cp -R ${{ env.APP_ROOT }}/{assets,charts,extensions,index.yaml} ./
+          git add ./{assets,charts,extensions,index.yaml} --force
+          git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
+          git push
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.1
+        with:
+          charts_dir: ${{ env.APP_ROOT }}/charts/*
+        env:
+          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          CR_SKIP_EXISTING: true

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -3,26 +3,23 @@ name: Build and Release Extension
 on:
   push:
     branches:
-      # TODO: RC
-      - package-helm
+      - main
   pull_request:
     branches:
-      # TODO: RC
-      - package-helm
+      - main
   workflow_dispatch:
 
 
 defaults:
   run:
     shell: bash
-    # TODO: RC
     working-directory: ./dashboard
 
 env:
   ACTIONS_RUNNER_DEBUG: true
   CI_COMMIT_MESSAGE: CI Build Artifacts
   # should match branches from `on` triggers
-  DEFAULT_BRANCH: package-helm
+  DEFAULT_BRANCH: main
   # should match default `working-directory`
   APP_ROOT: ./dashboard
 

--- a/dashboard/pkg/epinio/README.md
+++ b/dashboard/pkg/epinio/README.md
@@ -1,0 +1,7 @@
+<!-- This file is the description shown in Rancher Manager when browsing extensions -->
+An extension for Rancher Manager which allows you to manage Epinio resources.
+
+After installation, go to the main menu and click on the `Global Apps` / `Epinio` menu item. Rancher Manager will discover Epinio instances
+and allow you to navigate to them. This experience will be similar, and in places better, than the standalone Epinio UI.
+
+Epinio takes your application from source code to deployment and allow for Developers and Operators to work better together. For more information see https://epinio.io.

--- a/dashboard/pkg/epinio/README.md
+++ b/dashboard/pkg/epinio/README.md
@@ -1,7 +1,6 @@
 <!-- This file is the description shown in Rancher Manager when browsing extensions -->
 An extension for Rancher Manager which allows you to manage Epinio resources.
 
-After installation, go to the main menu and click on the `Global Apps` / `Epinio` menu item. Rancher Manager will discover Epinio instances
-and allow you to navigate to them. This experience will be similar, and in places better, than the standalone Epinio UI.
+After installation, go to the main menu and click on the `Global Apps` / `Epinio` menu item. Rancher Manager will discover Epinio instances and allow you to navigate to them. This experience will be similar, and in places better, than the standalone Epinio UI.
 
 Epinio takes your application from source code to deployment and allow for Developers and Operators to work better together. For more information see https://epinio.io.

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -7,15 +7,31 @@ The Epinio UI is currently served via the [Rancher Dashboard](https://github.com
 ### Running the UI
 #### Built-in / Embedded
 
-> The below instructions are obsolete and will be updated as part of https://github.com/epinio/ui/issues/247
-
 > You will still need an instance of Rancher and the Epinio hosting cluster needs to be added/imported to it.
 
 > Follow the Epinio docs or [this guide](install-epinio.md) to install an Epinio instance locally
 
-Code can be found in `rancher/dashboard` `epinio-dev`
+##### Developer Flow
+1. Build and serve the epinio extension
+   - `cd dashboard`
+   - `yarn build-pkg epinio`
+   - `yarn serve-pkgs`
+2. Install the dev epinio extension in Rancher
+   - Nav to burger menu --> `Extensions`
+   - Click three dot menu top right --> `Developer Load`
+      - If this is not visible, go to user avatar top right --> Preferences. Check the `Advanced Features` / `Enable Extension developer features` option
+   - Extension URL: Copy & Paste the value output when running `yarn serve-pkgs` above
+   - Extension module name: This should auto populate after entering the url
+   - Check the `Persist extension by creating custom resource` option (otherwise after each page refresh you'll need to load the extension)
 
-Run the dashboard as per instructions in `rancher/dashboard`
+##### Production Flow
+> This isn't supported yet, but to use the pending bits...
+1. Create the pending epinio extension repo
+   - In Rancher nav to the `local` cluster --> `Apps` / `Repositories` --> `Create`
+   - Enter Name: `epinio`, Index URL: `https://epinio.github.io/ui`, click `Create`
+2. Install the pending epinio extension in Rancher
+   - Nav to burger menu --> `Extensions` --> `Available` tab
+   - Find `Epinio` and click `Install`
 
 #### Standalone
 
@@ -31,15 +47,7 @@ In order to assist Epinio UI end-to-end tests we should ensure that it's easy to
 
 ### Built-in / Embedded
 
-> The below instructions are obsolete and will be updated as part of https://github.com/epinio/ui/issues/247
-
-While the Epinio UI code lives in the `rancher/dashboard` repo builds are created via the same Dashboard [build process](https://drone-publish.rancher.io/rancher/dashboard) and are triggered on..
-- Merging code to the `epinio-dev` branch (output served at `https://releases.rancher.com/dashboard/epinio-dev`)
-- Tagging one of the epinio branches (output available via `https://releases.rancher.com/dashboard/<tag name>`)
-
-The outputted build (`epinio-dev` or `<tag>`) can then be used in the `ui-dashboard-index` value as described in the root [README](https://github.com/epinio/ui)
-
-So to make a release simply tag with something like `epinio-v0.6.1-0.0.1`.
+Any merge to `main` will kick off a build of the epinio extension with a version matching that from `dashboard/pkg/epinio/package.json. If there is an existing release with the same name it will overwrite it.
 
 ### Standalone
 


### PR DESCRIPTION
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #247
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- see https://rancher.github.io/dashboard/extensions/extensions-getting-started#creating-a-release for details
- there is now a gh workflow that will build the extension on merge
- `gh-pages` now acts as a helm repo which can be added to rancher to install extension

### Technical notes summary
- the build-container workflow, to support extensions in air-gapped installs, is currently disabled (see comment in file)
