### PR TITLE
Ensure release-next builds complete by ignoring files that aren't checked in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,7 @@ backend/src/jetstream/extra_plugins.go
 go-vendor-*.tgz
 
 /scan_tmp
+
+# Build
+# Ensure goreleaser works by ignoring anything created in build process - https://goreleaser.com/errors/dirty/
+dashboard/release


### PR DESCRIPTION
- release-next build failed overnight given merge of ui backend in to ui repo
  - https://github.com/epinio/ui/actions/runs/5757557616/job/15608790038
  - ```
     ⨯ release failed after 0s                  error=git is in a dirty state
     Please check in your pipeline what can be changing the following files:
     ?? dashboard/release/
    ```
- Add `dashboard/release` is a directory created during the build of the ui, add it to the gitignore file 