### PR TITLE
Fix release workflows by adding /dashboard/release to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /tmp
 /out-tsc
 
+# Needed after migrating ui-backend
+/dashboard/release
+
 # Runtime data
 pids
 *.pid


### PR DESCRIPTION
This should address an issue with current release*.yml workflows which fail on [`error=git is in a dirty state`](https://github.com/epinio/ui/actions/runs/5780163481/job/15663453898#step:13:59)

I was able reproduce this issue on my fork and adding `/dashboard/release` dir to `.gitignore` resolved the issue.