### PR TITLE
Goreleaser and Dockerfile mods after migrating ui-backend

### DIFF
--- a/backend/.goreleaser-next.yml
+++ b/backend/.goreleaser-next.yml
@@ -78,6 +78,7 @@ dockers:
     goos: linux
     goarch: amd64
     use: buildx
+    dockerfile: backend/Dockerfile
 
     ids:
     - epinio-ui-amd64
@@ -98,13 +99,14 @@ dockers:
     - "--platform=linux/amd64"
 
     extra_files:
-    - ui/
+    - backend/ui/
 
   # arm64
   - id: epinio-ui-arm64
     goos: linux
     goarch: arm64
     use: buildx
+    dockerfile: backend/Dockerfile
 
     ids:
     - epinio-ui-arm64
@@ -125,13 +127,14 @@ dockers:
     - "--platform=linux/arm64/v8"
 
     extra_files:
-    - ui/
+    - backend/ui/
 
   # s390x
   - id: epinio-ui-s390x
     goos: linux
     goarch: s390x
     use: buildx
+    dockerfile: backend/Dockerfile
 
     ids:
     - epinio-ui-s390x
@@ -152,7 +155,7 @@ dockers:
     - "--platform=linux/s390x"
 
     extra_files:
-    - ui/
+    - backend/ui/
 
 docker_manifests:
   - id: epinio-ui

--- a/backend/.goreleaser.yml
+++ b/backend/.goreleaser.yml
@@ -75,6 +75,7 @@ dockers:
     goos: linux
     goarch: amd64
     use: buildx
+    dockerfile: backend/Dockerfile
 
     # IDs to filter the binaries/packages.
     ids:
@@ -110,13 +111,14 @@ dockers:
     # This field does not support wildcards, you can add an entire folder here
     # and use wildcards when you `COPY`/`ADD` in your Dockerfile.
     extra_files:
-    - ui/
+    - backend/ui/
 
   # arm64
   - id: epinio-ui-arm64
     goos: linux
     goarch: arm64
     use: buildx
+    dockerfile: backend/Dockerfile
 
     # IDs to filter the binaries/packages.
     ids:
@@ -152,13 +154,14 @@ dockers:
     # This field does not support wildcards, you can add an entire folder here
     # and use wildcards when you `COPY`/`ADD` in your Dockerfile.
     extra_files:
-    - ui/
+    - backend/ui/
 
   # s390x
   - id: epinio-ui-s390x
     goos: linux
     goarch: s390x
     use: buildx
+    dockerfile: backend/Dockerfile
 
     # IDs to filter the binaries/packages.
     ids:
@@ -194,7 +197,7 @@ dockers:
     # This field does not support wildcards, you can add an entire folder here
     # and use wildcards when you `COPY`/`ADD` in your Dockerfile.
     extra_files:
-    - ui/
+    - backend/ui/
 
 docker_manifests:
   -

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,6 @@ FROM registry.suse.com/bci/bci-micro
 ARG DIST_BINARY=src/jetstream/jetstream
 COPY ${DIST_BINARY} /epinio-ui
 
-COPY ui /ui
+COPY backend/ui /ui
 
 ENTRYPOINT ["/epinio-ui"]


### PR DESCRIPTION
This should fix the release workflows after migrating ui-backend. Not sure if this is the correct way how to do it, I don't like esp. the Dockerfile COPY change. 

Release-next workflow tested slighly in my personal fork - the publishing part failed as I didn't provide any TOKEN secrets for ghcr.