### PR TITLE
[ui] Add/Edit service chart values

### DIFF
--- a/dashboard/pkg/epinio/components/settings/ChartValues.vue
+++ b/dashboard/pkg/epinio/components/settings/ChartValues.vue
@@ -1,0 +1,148 @@
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+import formRulesGenerator from '@shell/utils/validators/formRules';
+import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
+import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
+import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
+
+interface Data {
+  valid: { [key: string]: boolean }
+}
+
+// Data, Methods, Computed, Props
+export default Vue.extend<Data, any, any, any>({
+  components: {
+    Checkbox,
+    LabeledInput,
+    LabeledSelect,
+  },
+
+  props: {
+    chart: {
+      type:     Object as PropType<{ [key: string]: object }>,
+      required: true
+    },
+    value: {
+      type:     Object as PropType<{ [key: string]: any }>,
+      required: true
+    },
+    title: {
+      type:    String,
+      default: 'Settings'
+    },
+    mode: {
+      type:     String,
+      required: true
+    },
+  },
+
+  data() {
+    return { valid: {} };
+  },
+
+  watch: {
+    valid(neu) {
+      this.$emit('valid', neu);
+    }
+  },
+
+  methods: {
+    rules(key: string, min: any, max: any) {
+      const frg = formRulesGenerator(this.$store.getters['i18n/t'], { key });
+      const minRule = frg.minValue(min);
+      const maxRule = frg.maxValue(max);
+
+      return (value: string) => {
+        const messages = [];
+
+        if (value) {
+          const minRes = minRule(value);
+
+          if (minRes) {
+            messages.push(minRes);
+          }
+
+          const maxRes = maxRule(value);
+
+          if (maxRes) {
+            messages.push(maxRes);
+          }
+        }
+        Vue.set(this.valid, key, !messages.length);
+
+        return messages.join(',');
+      };
+    },
+
+    numericPlaceholder(setting: any) {
+      if (setting.maximum && setting.minimum) {
+        return `${ setting.minimum } to ${ setting.maximum }`;
+      } else if (setting.maximum) {
+        return `<= ${ setting.maximum }`;
+      } else if (setting.minimum) {
+        return `>= ${ setting.minimum }`;
+      } else {
+        return '';
+      }
+    },
+  },
+});
+</script>
+
+<template>
+  <div class="chart-values">
+    <h3>{{ title }}</h3>
+    <div
+      v-for="(setting, key) in chart"
+      :key="key"
+      class="chart-values-item"
+    >
+      <LabeledInput
+        v-if="setting.type === 'number' || setting.type === 'integer'"
+        :id="key"
+        v-model="value[key]"
+        :label="key"
+        type="number"
+        :min="setting.minimum"
+        :max="setting.maximum"
+        :rules="[rules(key, setting.minimum, setting.maximum)]"
+        :tooltip="numericPlaceholder(setting)"
+        :mode="mode"
+      />
+      <Checkbox
+        v-else-if="setting.type === 'bool'"
+        :id="key"
+        :value="value[key] === 'true'"
+        :label="key"
+        :mode="mode"
+        @input="value[key] = $event ? 'true' : 'false'"
+      />
+      <LabeledSelect
+        v-else-if="setting.type === 'string' && setting.enum"
+        :id="key"
+        v-model="value[key]"
+        :label="key"
+        :options="setting.enum"
+        :mode="mode"
+      />
+      <LabeledInput
+        v-else-if="setting.type === 'string'"
+        :id="key"
+        v-model="value[key]"
+        :label="key"
+        :mode="mode"
+      />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .chart-values {
+    display: flex;
+    flex-direction: column;
+
+    &-item:not(:last-of-type) {
+        margin-bottom: 20px;
+    }
+  }
+</style>

--- a/dashboard/pkg/epinio/components/settings/ChartValues.vue
+++ b/dashboard/pkg/epinio/components/settings/ChartValues.vue
@@ -34,6 +34,10 @@ export default Vue.extend<Data, any, any, any>({
       type:     String,
       required: true
     },
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
   },
 
   data() {
@@ -108,6 +112,7 @@ export default Vue.extend<Data, any, any, any>({
         :rules="[rules(key, setting.minimum, setting.maximum)]"
         :tooltip="numericPlaceholder(setting)"
         :mode="mode"
+        :disabled="disabled"
       />
       <Checkbox
         v-else-if="setting.type === 'bool'"
@@ -115,6 +120,7 @@ export default Vue.extend<Data, any, any, any>({
         :value="value[key] === 'true'"
         :label="key"
         :mode="mode"
+        :disabled="disabled"
         @input="value[key] = $event ? 'true' : 'false'"
       />
       <LabeledSelect
@@ -124,6 +130,7 @@ export default Vue.extend<Data, any, any, any>({
         :label="key"
         :options="setting.enum"
         :mode="mode"
+        :disabled="disabled"
       />
       <LabeledInput
         v-else-if="setting.type === 'string'"
@@ -131,6 +138,7 @@ export default Vue.extend<Data, any, any, any>({
         v-model="value[key]"
         :label="key"
         :mode="mode"
+        :disabled="disabled"
       />
     </div>
   </div>

--- a/dashboard/pkg/epinio/components/settings/ChartValues.vue
+++ b/dashboard/pkg/epinio/components/settings/ChartValues.vue
@@ -89,6 +89,10 @@ export default Vue.extend<Data, any, any, any>({
         return '';
       }
     },
+
+    onInputCheckbox(key: string, value: boolean) {
+      Vue.set(this.value, key, value ? 'true' : 'false');
+    }
   },
 });
 </script>
@@ -121,7 +125,7 @@ export default Vue.extend<Data, any, any, any>({
         :label="key"
         :mode="mode"
         :disabled="disabled"
-        @input="value[key] = $event ? 'true' : 'false'"
+        @input="onInputCheckbox(key, $event)"
       />
       <LabeledSelect
         v-else-if="setting.type === 'string' && setting.enum"

--- a/dashboard/pkg/epinio/edit/services.vue
+++ b/dashboard/pkg/epinio/edit/services.vue
@@ -55,7 +55,7 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
       this.mixinFetch()
     ]);
 
-    Vue.set(this.value, 'catalog_service', this.selectedCatalogService?.meta.name || null);
+    Vue.set(this.value, 'catalog_service', this.selectedCatalogService?.meta.name || this.$route.query[EPINIO_SERVICE_PARAM] || null);
     Vue.set(this.value.meta, 'namespace', this.initialValue.meta.namespace || this.namespaces[0]?.meta.name);
   },
 
@@ -135,7 +135,7 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
     },
 
     showChartValues() {
-      return Object.keys(this.selectedCatalogService?.settings || []).length !== 0;
+      return Object.keys(this.selectedCatalogService?.settings || {}).length !== 0;
     }
   },
 

--- a/dashboard/pkg/epinio/edit/services.vue
+++ b/dashboard/pkg/epinio/edit/services.vue
@@ -51,7 +51,7 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
       this.mixinFetch()
     ]);
 
-    Vue.set(this.value, 'catalog_service', this.$route.query[EPINIO_SERVICE_PARAM]);
+    Vue.set(this.value, 'catalog_service', this.selectedCatalogService?.meta.name || null);
     Vue.set(this.value.meta, 'namespace', this.initialValue.meta.namespace || this.namespaces[0]?.meta.name);
   },
 

--- a/dashboard/pkg/epinio/edit/services.vue
+++ b/dashboard/pkg/epinio/edit/services.vue
@@ -170,6 +170,11 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
         saveCb(false);
       }
     },
+    resetChartValues() {
+      this.chartValues = {};
+      this.value.settings = null;
+      this.validChartValues = {};
+    }
   },
 
   watch: {
@@ -223,6 +228,7 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
           :label-key="'epinio.serviceInstance.create.catalogService.label'"
           :placeholder="$fetchState.pending || noCatalogServices ? t('epinio.serviceInstance.create.catalogService.placeholderNoOptions') : t('epinio.serviceInstance.create.catalogService.placeholderWithOptions')"
           required
+          @option:selected="resetChartValues"
         />
       </div>
     </div>

--- a/dashboard/pkg/epinio/edit/services.vue
+++ b/dashboard/pkg/epinio/edit/services.vue
@@ -71,9 +71,13 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
 
   mounted() {
     if (this.mode !== 'create') {
-      this.value.details().then((details: any) => {
-        this.chartValues = details?.settings || {};
+      const serviceDetails = this.$store.dispatch('epinio/find', {
+        type: EPINIO_TYPES.SERVICE_INSTANCE,
+        id:   `${ this.value.metadata?.namespace }/${ this.value.metadata?.name }`,
+        opt:  { force: true }
       });
+
+      this.chartValues = serviceDetails?.settings || {};
     }
   },
 

--- a/dashboard/pkg/epinio/edit/services.vue
+++ b/dashboard/pkg/epinio/edit/services.vue
@@ -64,21 +64,9 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
       errors:                 [],
       failedWaitingForDeploy: false,
       selectedApps:           this.value.boundapps || [],
-      chartValues:            {},
+      chartValues:            this.value.settings || {},
       validChartValues:       {}
     };
-  },
-
-  mounted() {
-    if (this.mode !== 'create') {
-      const serviceDetails = this.$store.dispatch('epinio/find', {
-        type: EPINIO_TYPES.SERVICE_INSTANCE,
-        id:   `${ this.value.metadata?.namespace }/${ this.value.metadata?.name }`,
-        opt:  { force: true }
-      });
-
-      this.chartValues = serviceDetails?.settings || {};
-    }
   },
 
   computed: {

--- a/dashboard/pkg/epinio/edit/services.vue
+++ b/dashboard/pkg/epinio/edit/services.vue
@@ -248,11 +248,13 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
     >
       <div class="col span-6">
         <div class="spacer" />
+        <!-- EDIT mode is not supported -->
         <ChartValues
           v-model="chartValues"
           :chart="selectedCatalogService.settings"
           :title="t('epinio.services.chartValues.title')"
           :mode="mode"
+          :disabled="mode === 'edit'"
           @valid="validChartValues = $event"
         />
       </div>

--- a/dashboard/pkg/epinio/l10n/en-us.yaml
+++ b/dashboard/pkg/epinio/l10n/en-us.yaml
@@ -305,6 +305,8 @@ epinio:
       }
     promptRemove:
       attemptingToRemove: You are attempting to delete the Service Instance
+    chartValues:
+      title: Service Variables
   configurations:
     pairs:
       label: Config Data

--- a/dashboard/pkg/epinio/models/services.js
+++ b/dashboard/pkg/epinio/models/services.js
@@ -95,11 +95,4 @@ export default class EpinioServiceModel extends EpinioNamespacedResource {
   bulkRemove(items, opt) {
     return bulkRemove(items, opt);
   }
-
-  async details() {
-    return await this.followLink('self', {
-      method:  'get',
-      headers: { accept: 'application/json' }
-    });
-  }
 }

--- a/dashboard/pkg/epinio/models/services.js
+++ b/dashboard/pkg/epinio/models/services.js
@@ -56,7 +56,8 @@ export default class EpinioServiceModel extends EpinioNamespacedResource {
       },
       data: {
         name:            this.name,
-        catalog_service: this.catalog_service
+        catalog_service: this.catalog_service,
+        settings:        this.settings
       }
     });
   }
@@ -93,5 +94,12 @@ export default class EpinioServiceModel extends EpinioNamespacedResource {
 
   bulkRemove(items, opt) {
     return bulkRemove(items, opt);
+  }
+
+  async details() {
+    return await this.followLink('self', {
+      method:  'get',
+      headers: { accept: 'application/json' }
+    });
   }
 }

--- a/dashboard/pkg/epinio/utils/settings.ts
+++ b/dashboard/pkg/epinio/utils/settings.ts
@@ -1,0 +1,11 @@
+export function objValuesToString(obj: any) {
+  const copy = { ...obj };
+
+  for (const key in copy) {
+    if (typeof copy[key] !== 'string') {
+      copy[key] = String(copy[key]);
+    }
+  }
+
+  return copy;
+}


### PR DESCRIPTION
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes epinio/ui#252
Fixes epinio/ui#296
<!-- Define findings related to the feature or bug issue. -->

### Technical Notes
- How to create service chart settings for a Service Catalog: https://docs.epinio.io/howtos/create_custom_service#user-settable-configuration-values
- Epinio 1.9.0 supports only basic key-value `string` maps.
- Edit service chart values is not supported at the moment. The chart fields are disabled in edit mode.

### Screenshots

View:
![image](https://github.com/epinio/ui/assets/26394656/a07d0780-6054-4d28-93a8-066426269f32)

Create:
![image](https://github.com/epinio/ui/assets/26394656/ef1eaf06-e7ca-4919-9b26-c12b2220567b)

Edit:
![image](https://github.com/epinio/ui/assets/26394656/9d4f8663-c724-4699-bbf7-8c2ecb9d3044)
