### PR TITLE
Fix crash navigating to cluster explorer

### DIFF
--- a/dashboard/pkg/epinio/models/epinio-namespaced-resource.js
+++ b/dashboard/pkg/epinio/models/epinio-namespaced-resource.js
@@ -77,7 +77,7 @@ export default class EpinioMetaResource extends EpinioResource {
   get namespaceLocation() {
     return createEpinioRoute(`c-cluster-resource-id`, {
       cluster:  this.$rootGetters['clusterId'],
-      resource: this.schema.id,
+      resource: this.schema?.id,
       id:       this.meta.namespace,
     });
   }


### PR DESCRIPTION
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #307
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The property `schema` is null when navigating from embedded Epinio to cluster explorer.

```
  get namespaceLocation() {
    return createEpinioRoute(`c-cluster-resource-id`, {
      cluster:  this.$rootGetters['clusterId'],
      resource: this.schema.id,
      id:       this.meta.namespace,
    });
  }
```

Is it probably a side effect of routing which triggers a reload of Epinio pages?
Using the optional operator works fine though, `namespaceLocation` is not required when moving out from Epinio.