### PR TITLE
Fix custom variables validation in Application edit mode

### DIFF
--- a/dashboard/pkg/epinio/edit/applications.vue
+++ b/dashboard/pkg/epinio/edit/applications.vue
@@ -192,7 +192,7 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
     updateManifestConfigurations(changes: string[]) {
       this.set(this.value.configuration, { configurations: changes });
     },
-    validate(value, tab) {
+    validate(value: boolean, tab: string) {
       if (tab) {
         this.tabErrors[tab] = !value;
       }

--- a/dashboard/pkg/epinio/edit/applications.vue
+++ b/dashboard/pkg/epinio/edit/applications.vue
@@ -73,7 +73,8 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
           previousButton: { disable: true }
         },
       ],
-      epinioInfo: undefined
+      epinioInfo: undefined,
+      tabErrors:  { appInfo: false }
     };
   },
 
@@ -191,6 +192,13 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
     updateManifestConfigurations(changes: string[]) {
       this.set(this.value.configuration, { configurations: changes });
     },
+    validate(value, tab) {
+      if (tab) {
+        this.tabErrors[tab] = !value;
+      }
+
+      this.steps[0].ready = value;
+    }
   },
 });
 </script>
@@ -204,6 +212,7 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
     :mode="mode"
     :resource="value"
     :errors="errors"
+    :validation-passed="steps[0].ready"
     @error="e=>errors = e"
     @finish="save"
   >
@@ -258,11 +267,13 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
         label-key="epinio.applications.steps.basics.label"
         name="info"
         :weight="20"
+        :error="tabErrors.appInfo"
       >
         <AppInfo
           :application="value"
           :mode="mode"
           @change="updateInfo"
+          @valid="validate($event, 'appInfo')"
         />
       </Tab>
       <Tab

--- a/dashboard/pkg/epinio/edit/applications.vue
+++ b/dashboard/pkg/epinio/edit/applications.vue
@@ -112,6 +112,9 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
     showSourceTab() {
       return this.mode === _EDIT;
     },
+    validationPassed() {
+      return !Object.values(this.tabErrors).find((error) => error);
+    }
   },
 
   methods: {
@@ -197,6 +200,7 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
         this.tabErrors[tab] = !value;
       }
 
+      // UpdateSource wizard will save settings as well, needs to disable the button in case of errors
       this.steps[0].ready = value;
     }
   },
@@ -212,7 +216,7 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
     :mode="mode"
     :resource="value"
     :errors="errors"
-    :validation-passed="steps[0].ready"
+    :validation-passed="validationPassed"
     @error="e=>errors = e"
     @finish="save"
   >


### PR DESCRIPTION
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #299 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Disable 'Save' button when the custom settings are not valid
- Disable 'Update Source' when the custom settings in the Details tab are not valid.
- Show errors in Details tab's header.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
In the example below, the validation failed because 'foo' field has a minimum value.

Button Disabled
![image](https://github.com/epinio/ui/assets/26394656/eb9e1424-e94f-4f89-a731-a37dfa0c56e0)

Tab errors
![image](https://github.com/epinio/ui/assets/26394656/0d9dc82d-3a01-4271-bb20-597fbce2fa2a)


