### PR TITLE
Use correct colour for text in home page version blob

### DIFF
--- a/dashboard/pkg/epinio/pages/c/_cluster/dashboard.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/dashboard.vue
@@ -363,7 +363,7 @@ export default Vue.extend<any, any, any, any>({
 
       span {
         background: var(--primary);
-        color: var(--body-text);
+        color: var(--primary-text);
         border-radius: var(--border-radius);
         padding: 4px 8px;
       }


### PR DESCRIPTION


<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #323
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
--primary-text is the text colour for --primary backgrounds

```
  --primary                    : #{$primary};
  --primary-text               : #{contrast-color($primary)};
```
