### PR TITLE
Redirect namespace links in masthead to namespace list with filter

### DIFF
--- a/dashboard/pkg/epinio/list/namespaces.vue
+++ b/dashboard/pkg/epinio/list/namespaces.vue
@@ -151,6 +151,7 @@ export default {
       :groupable="false"
       :schema="schema"
       key-field="_key"
+      :useQueryParamsForSimpleFiltering="true"
       v-on="$listeners"
     />
     <div

--- a/dashboard/pkg/epinio/models/epinio-namespaced-resource.js
+++ b/dashboard/pkg/epinio/models/epinio-namespaced-resource.js
@@ -1,3 +1,4 @@
+import { EPINIO_TYPES } from '../types';
 import { createEpinioRoute } from '../utils/custom-routing';
 import EpinioResource from './epinio-resource';
 
@@ -75,11 +76,14 @@ export default class EpinioMetaResource extends EpinioResource {
   }
 
   get namespaceLocation() {
-    return createEpinioRoute(`c-cluster-resource-id`, {
+    // This should normally redirect the user to the namespace details page.
+    // However none exists in epinio, so go to the list view with a filter for the name.
+    // This could result in false positives (namespaces: a, aa, aaa would all show up if user when to view namespace with name `a`)
+    // but is better than a dead end
+    return createEpinioRoute(`c-cluster-resource`, {
       cluster:  this.$rootGetters['clusterId'],
-      resource: this.schema?.id,
-      id:       this.meta.namespace,
-    });
+      resource: EPINIO_TYPES.NAMESPACE,
+    }, { query: { q: this.meta.namespace } });
   }
 
   async forceFetch() {


### PR DESCRIPTION
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #324
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- For resources that are namespaced, the masthead shows a link to the namespace
- In dashboard world that would be the detail page of a namespace resource
- In epinio world we have no namespace detail page, so take user to namespace list with query filter to show it
- This could result in false positives but is better than a dead end
  - namespaces `a`, `aa` and `aaa` would all show up if user went to view namespace with name `a`
