### PR TITLE
[fix] Fix binding to an app to a service after that service is created

### DIFF
--- a/dashboard/pkg/epinio/config/epinio.ts
+++ b/dashboard/pkg/epinio/config/epinio.ts
@@ -29,7 +29,7 @@ export function init($plugin: any, store: any) {
       logoRoute:           createEpinioRoute('c-cluster-dashboard', { cluster: EPINIO_STANDALONE_CLUSTER_NAME }),
       disableSteveSockets: true,
       getVersionInfo:      (store:any) => {
-        const { displayVersion } = store.getters[`${ EPINIO_PRODUCT_NAME }/version`]();
+        const { displayVersion } = store.getters[`${ EPINIO_PRODUCT_NAME }/version`]() || { };
 
         return displayVersion || 'unknown';
       },

--- a/dashboard/pkg/epinio/edit/bind-apps-mixin.js
+++ b/dashboard/pkg/epinio/edit/bind-apps-mixin.js
@@ -33,15 +33,18 @@ export default {
       await serviceInstance.waitForTestFn(() => {
         const freshServiceInstance = this.$store.getters['epinio/byId'](EPINIO_TYPES.SERVICE_INSTANCE, `${ serviceInstance.meta.namespace }/${ serviceInstance.meta.name }`);
 
-        if (freshServiceInstance?.state === 'deployed') {
+        if (freshServiceInstance?.state === 'not-ready') {
           return true;
         }
         // This is an async fn, but we're in a sync fn. It might create a backlog if previous requests don't complete in time
         serviceInstance.forceFetch();
-      }, `service instance state = "deployed"`, 30000, 2000).catch((err) => {
+      }, `service instance state = "not-ready"`, 30000, 2000).catch((err) => {
         console.warn(err); // eslint-disable-line no-console
         throw new Error('waitingForDeploy');
       });
+
+      // Wait, because `not-ready` does not indicate service is ready to bind to. See https://github.com/epinio/ui/issues/289
+      await new Promise((res) => setTimeout(res, 2000), () => {});
     },
 
     async updateConfigurationAppBindings() {


### PR DESCRIPTION
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #289
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Before we would wait for the service state to be deployed
- this can take longer than the allowed 30 seconds to happen, and we don't have to wait for that state
- so now wait for the service to be created, then an an additional horrible 2 second wait to be sure

Also fix an issue where slow API requests could result in a missing version
