### PR TITLE
Fix edit service instance

### DIFF
--- a/dashboard/pkg/epinio/edit/services.vue
+++ b/dashboard/pkg/epinio/edit/services.vue
@@ -61,11 +61,11 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
 
   data() {
     return {
-      errors:                 [],
-      failedWaitingForDeploy: false,
-      selectedApps:           this.value.boundapps || [],
-      chartValues:            this.value.settings || {},
-      validChartValues:       {}
+      errors:                          [],
+      failedWaitingForServiceInstance: false,
+      selectedApps:                    this.value.boundapps || [],
+      chartValues:                     this.value.settings || {},
+      validChartValues:                {}
     };
   },
 
@@ -89,7 +89,7 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
       const nsErrors = validateKubernetesName(this.value?.meta.namespace || '', '', this.$store.getters, undefined, []);
 
       if (nameErrors.length === 0 && nsErrors.length === 0) {
-        return !this.failedWaitingForDeploy;
+        return !this.failedWaitingForServiceInstance;
       }
 
       return false;
@@ -153,9 +153,9 @@ export default Vue.extend<Data, EpinioCompRecord, EpinioCompRecord, EpinioCompRe
           this.done();
         }
       } catch (err: Error | any) {
-        if (err.message === 'waitingForDeploy') {
-          Vue.set(this, 'failedWaitingForDeploy', true);
-          this.errors = [this.t('epinio.serviceInstance.create.catalogService.failedWaitingForDeploy')];
+        if (err.message === 'waitingForServiceInstance') {
+          Vue.set(this, 'failedWaitingForServiceInstance', true);
+          this.errors = [this.t('epinio.serviceInstance.create.catalogService.failedWaitingForServiceInstance')];
         } else {
           this.errors = epinioExceptionToErrorsArray(err);
         }

--- a/dashboard/pkg/epinio/l10n/en-us.yaml
+++ b/dashboard/pkg/epinio/l10n/en-us.yaml
@@ -350,7 +350,7 @@ epinio:
         label: Catalog Service
         placeholderNoOptions: There are no services
         placeholderWithOptions: Select the type of Service to create
-        failedWaitingForDeploy: Service instance was created but failed to reach a deployed state in a reasonable amount of time, no applications were bound
+        failedWaitingForServiceInstance: Service instance was created but failed to be returned by Epinio, no applications were bound
   catalogService:
     tableHeaders:
       shortDesc: Headline


### PR DESCRIPTION

<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Relates to https://github.com/epinio/ui/issues/289
Fixes: #341
Fixes: #342
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- when editing a service instance that's in state 'deployed' we'd wait for the `not-ready` state which was never reached
- we now just wait for the service instance to be created
- also fixed failure message
