### PR TITLE
Ensure we use an endpoint that requires auth when checking creds

### DIFF
--- a/backend/src/jetstream/authepinio.go
+++ b/backend/src/jetstream/authepinio.go
@@ -182,7 +182,7 @@ func (a *epinioAuth) verifyLocalLoginCreds(username, password string) error {
 	}
 
 	// Make a request to the epinio endpoint that requires auth
-	credsUrl := fmt.Sprintf("%s/api/v1/info", epinioEndpoint.APIEndpoint.String())
+	credsUrl := fmt.Sprintf("%s/api/v1/me", epinioEndpoint.APIEndpoint.String())
 
 	req, err := http.NewRequest("GET", credsUrl, nil)
 	if err != nil {

--- a/backend/src/jetstream/plugins/epinio/main.go
+++ b/backend/src/jetstream/plugins/epinio/main.go
@@ -143,7 +143,7 @@ func (epinio *Epinio) Register(echoContext echo.Context) error {
 func (epinio *Epinio) Validate(userGUID string, cnsiRecord interfaces.CNSIRecord, tokenRecord interfaces.TokenRecord) error {
 	// Validate is used to confirm the user's creds after the user connects
 	// For this flow we don't need to do this, it was done when the user logs in in authepinio
-	// (makes a request to `/api/v1/info`)
+	// (makes a request to `/api/v1/me`)
 	return nil
 }
 


### PR DESCRIPTION
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #356
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- we requested the info endpoint be made public (no auth required) to support an embedded use case
- however we also used that endpoint to validate the user supplied creds were valid
- end result was the ui thinking that bad creds were valid, causing the error page to show before redirecting back to log in
- fix is to use the new `me` endpoint

### Technical notes summary
- requires fairly recent epinio running (from 31b276, merged 3 days ago
