### PR TITLE
Ensure dex redirect url is correct when running in production

### DIFF
--- a/dashboard/pkg/epinio/models/cluster.ts
+++ b/dashboard/pkg/epinio/models/cluster.ts
@@ -1,6 +1,7 @@
 import Resource from '@shell/plugins/dashboard-store/resource-class';
 import { EPINIO_TYPES } from '../types';
 import epinioAuth, { EpinioAuthConfig, EpinioAuthLocalConfig, EpinioAuthTypes } from '../utils/auth';
+import { dashboardUrl } from '../utils/embedded-helpers';
 
 export const EpinioInfoPath = `/api/v1/info`;
 
@@ -70,7 +71,7 @@ export default class EpinioCluster extends Resource {
       type,
       epinioUrl: this.api,
       dexConfig: {
-        dashboardUrl: window.origin,
+        dashboardUrl: dashboardUrl(),
         dexUrl:       this.api.replace('epinio', 'auth')
       },
       localConfig

--- a/dashboard/pkg/epinio/package.json
+++ b/dashboard/pkg/epinio/package.json
@@ -2,7 +2,7 @@
   "name": "epinio",
   "description": "Application Development Engine for Kubernetes",
   "icon": "https://raw.githubusercontent.com/rancher/dashboard/0b6cbe93e9ed3292294da178f119a500cc494db9/pkg/epinio/assets/logo-epinio.svg",
-  "version": "1.11.0-1",
+  "version": "1.11.0-2",
   "private": false,
   "rancher": true,
   "license": "Apache-2.0",

--- a/dashboard/pkg/epinio/pages/auth/verify.vue
+++ b/dashboard/pkg/epinio/pages/auth/verify.vue
@@ -2,6 +2,7 @@
 import Vue from 'vue';
 import epinioAuth from '../../utils/auth';
 import Banner from '@components/Banner/Banner.vue';
+import { dashboardUrl } from '../../utils/embedded-helpers';
 
 interface Data {
   error: string,
@@ -25,7 +26,7 @@ export default Vue.extend<Data, any, any, any>({
     } else {
       await epinioAuth.dexRedirect(route, {
         dexUrl:       document.referrer,
-        dashboardUrl: window.origin
+        dashboardUrl: dashboardUrl()
       });
     }
   },

--- a/dashboard/pkg/epinio/utils/embedded-helpers.ts
+++ b/dashboard/pkg/epinio/utils/embedded-helpers.ts
@@ -1,0 +1,9 @@
+export const dashboardUrl = () => {
+  const dashboardUrl = window.origin;
+
+  if (process.env.dev) {
+    return dashboardUrl;
+  }
+
+  return `${ dashboardUrl }/dashboard`;
+};

--- a/dashboard/pkg/epinio/utils/epinio-discovery.ts
+++ b/dashboard/pkg/epinio/utils/epinio-discovery.ts
@@ -2,6 +2,7 @@ import { MANAGEMENT } from '@shell/config/types';
 import { ingressFullPath } from '@shell/models/networking.k8s.io.ingress';
 import epinioAuth, { EpinioAuthTypes } from '../utils/auth';
 import EpinioCluster from '../models/cluster';
+import { dashboardUrl } from './embedded-helpers';
 
 export default {
   ingressUrl(clusterId: string) {
@@ -21,7 +22,7 @@ export default {
           type:      EpinioAuthTypes.AGNOSTIC,
           epinioUrl: url,
           dexConfig: {
-            dashboardUrl: window.origin,
+            dashboardUrl: dashboardUrl(),
             dexUrl:       url.replace('epinio', 'auth')
           },
         });


### PR DESCRIPTION
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
- rancher is served from `<rancher domain>/dashboard`
- when running locally though it's served from `localhost:8005`
- this is a fix to ensure the dex redirect url contains the /dashboard when in prod