### PR TITLE
Make UI agnostic of epinio's namespace and other improvements

### DIFF
--- a/dashboard/pkg/epinio/l10n/en-us.yaml
+++ b/dashboard/pkg/epinio/l10n/en-us.yaml
@@ -314,6 +314,8 @@ epinio:
         label: Redeploy
       goToEpinio:
         label: Epinio App
+      viewDeployment:
+        label: View In Kube Cluster
     wm:
       containerName: 'Instance: {label}'
       noData: There are no log entries to show.

--- a/dashboard/pkg/epinio/models/cluster.ts
+++ b/dashboard/pkg/epinio/models/cluster.ts
@@ -9,6 +9,7 @@ export default class EpinioCluster extends Resource {
 
   id: string;
   name: string;
+  namespace: string;
   state?: string;
   metadata?: { state: { transitioning: boolean, error: boolean, message: string }};
   loggedIn: boolean;
@@ -19,6 +20,7 @@ export default class EpinioCluster extends Resource {
   constructor(data: {
     id: string,
     name: string,
+    namespace: string,
     loggedIn: boolean,
     api: string,
     mgmtCluster: any,
@@ -26,6 +28,7 @@ export default class EpinioCluster extends Resource {
     super(data, ctx);
     this.id = data.id;
     this.name = data.name;
+    this.namespace = data.namespace;
     this.api = data.api;
     this.loggedIn = data.loggedIn;
     this.mgmtCluster = data.mgmtCluster;

--- a/dashboard/pkg/epinio/pages/c/_cluster/dashboard.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/dashboard.vue
@@ -154,12 +154,6 @@ export default Vue.extend<any, any, any, any>({
         this.sectionContent[2].isLoaded = true;
         this.sectionContent[2].isEnable = true;
       }
-    },
-    openMetricsDetails() {
-      this.$router.replace({
-        name:   'c-cluster-explorer',
-        params: { cluster: this.$store.getters['clusterId'] }
-      });
     }
   },
   computed: {
@@ -206,6 +200,12 @@ export default Vue.extend<any, any, any, any>({
 
       return { totalNamespaces: allNamespaces.length, latestNamespaces: sortBy(allNamespaces, 'metadata.createdAt').reverse().slice(0, 2) };
     },
+    metricsDetails() {
+      return {
+        name:   'c-cluster-explorer',
+        params: { cluster: this.$store.getters['clusterId'] }
+      };
+    }
   },
 });
 </script>
@@ -254,10 +254,11 @@ export default Vue.extend<any, any, any, any>({
       <span>
         {{ t('epinio.intro.metrics.availability', { availableCpu, availableMemory }) }}
       </span>
-      <a
-        class="cluster-link"
-        @click="openMetricsDetails"
-      >{{ t('epinio.intro.metrics.link.label') }}</a>
+      <n-link
+        :to="metricsDetails"
+      >
+        {{ t('epinio.intro.metrics.link.label') }}
+      </n-link>
     </Banner>
 
     <div class="get-started">

--- a/dashboard/pkg/epinio/store/epinio-store/actions.ts
+++ b/dashboard/pkg/epinio/store/epinio-store/actions.ts
@@ -1,4 +1,4 @@
-import { METRIC, SCHEMA, WORKLOAD, WORKLOAD_TYPES } from '@shell/config/types';
+import { METRIC, SCHEMA, WORKLOAD_TYPES } from '@shell/config/types';
 import { handleSpoofedRequest } from '@shell/plugins/dashboard-store/actions';
 import { classify } from '@shell/plugins/dashboard-store/classify';
 import { normalizeType } from '@shell/plugins/dashboard-store/normalize';
@@ -12,7 +12,7 @@ import {
 } from '../../types';
 import EpinioCluster from '../../models/cluster';
 import { RedirectToError } from '@shell/utils/error';
-import { allHash, allHashSettled } from '@shell/utils/promise';
+import { allHashSettled } from '@shell/utils/promise';
 
 const createId = (schema: any, resource: any) => {
   const name = resource.meta?.name || resource.name;

--- a/dashboard/pkg/epinio/store/epinio-store/actions.ts
+++ b/dashboard/pkg/epinio/store/epinio-store/actions.ts
@@ -1,4 +1,4 @@
-import { METRIC, SCHEMA } from '@shell/config/types';
+import { METRIC, SCHEMA, WORKLOAD, WORKLOAD_TYPES } from '@shell/config/types';
 import { handleSpoofedRequest } from '@shell/plugins/dashboard-store/actions';
 import { classify } from '@shell/plugins/dashboard-store/classify';
 import { normalizeType } from '@shell/plugins/dashboard-store/normalize';
@@ -12,6 +12,7 @@ import {
 } from '../../types';
 import EpinioCluster from '../../models/cluster';
 import { RedirectToError } from '@shell/utils/error';
+import { allHash, allHashSettled } from '@shell/utils/promise';
 
 const createId = (schema: any, resource: any) => {
   const name = resource.meta?.name || resource.name;
@@ -243,13 +244,18 @@ export default {
 
     if (!isSingleProduct) {
       try {
-        const nodeMetricsSchema = await dispatch(`cluster/request`, { url: `/k8s/clusters/${ clusterId }/v1/schemas/${ METRIC.NODE }` }, { root: true });
+        const schemas = await allHashSettled({
+          nodeMetrics: dispatch(`cluster/request`, { url: `/k8s/clusters/${ clusterId }/v1/schemas/${ METRIC.NODE }` }, { root: true }),
+          deployments: dispatch(`cluster/request`, { url: `/k8s/clusters/${ clusterId }/v1/schemas/${ WORKLOAD_TYPES.DEPLOYMENT }` }, { root: true })
+        });
 
-        if (nodeMetricsSchema) {
-          data.push(nodeMetricsSchema);
-        }
+        Object.values(schemas).forEach((res: any ) => {
+          if (res.value) {
+            data.push(res.value);
+          }
+        });
       } catch (e) {
-        console.warn(`Unable to fetch Node metrics schema for epinio cluster: ${ clusterId }`);// eslint-disable-line no-console
+        console.debug(`Unable to fetch schema/s for epinio cluster: ${ clusterId }`, e);// eslint-disable-line no-console
       }
     }
 

--- a/dashboard/pkg/epinio/utils/epinio-discovery.ts
+++ b/dashboard/pkg/epinio/utils/epinio-discovery.ts
@@ -3,10 +3,10 @@ import { ingressFullPath } from '@shell/models/networking.k8s.io.ingress';
 import epinioAuth, { EpinioAuthTypes } from '../utils/auth';
 import EpinioCluster from '../models/cluster';
 
-export default {
-  ingressUrl(clusterId: string) {
-    return `/k8s/clusters/${ clusterId }/v1/networking.k8s.io.ingresses/epinio/epinio`;
-  },
+class EpinioDiscovery {
+  ingressUrl(clusterId: string, namespace: string) {
+    return `/k8s/clusters/${ clusterId }/v1/networking.k8s.io.ingresses/${ namespace }/epinio`;
+  }
 
   async discover(store: any) {
     const allClusters = await store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }, { root: true });
@@ -14,9 +14,13 @@ export default {
 
     for (const c of allClusters.filter((c: any) => c.isReady)) {
       try {
+        // Try to discover the namespace epinio is installed to
+        const namespace = await this.findNamespace(store, c.id);
+
         // Get the url first, if it has this it's highly likely it's an epinio cluster
-        const epinioIngress = await store.dispatch(`cluster/request`, { url: this.ingressUrl(c.id) }, { root: true });
+        const epinioIngress = await store.dispatch(`cluster/request`, { url: this.ingressUrl(c.id, namespace) }, { root: true });
         const url = ingressFullPath(epinioIngress, epinioIngress.spec.rules?.[0]);
+
         const loggedIn = await epinioAuth.isLoggedIn({
           type:      EpinioAuthTypes.AGNOSTIC,
           epinioUrl: url,
@@ -29,15 +33,36 @@ export default {
         epinioClusters.push(new EpinioCluster({
           id:          c.id,
           name:        c.spec.displayName,
+          namespace,
           api:         url,
           loggedIn:    !!loggedIn,
           mgmtCluster: c
         }, { rootGetters: store.getters }));
       } catch (err) {
-        console.info(`Skipping epinio discovery for ${ c.spec.displayName }`, err); // eslint-disable-line no-console
+        console.debug(`Skipping epinio discovery for ${ c.spec.displayName }:`, err); // eslint-disable-line no-console
       }
     }
 
     return epinioClusters;
   }
-};
+
+  private async findNamespace(store: any, clusterId: string): Promise<string> {
+    // Attempt to find the `epinio-server` deployment. This assumes the user had read rights to resources in the target namespace
+    const url = `/k8s/clusters/${ clusterId }/v1/apps.deployments?labelSelector=app.kubernetes.io/component%3Depinio,app.kubernetes.io/name%3Depinio-server`;
+    const deployments = await store.dispatch(`cluster/request`, { url }, { root: true });
+
+    if (!deployments?.data?.length) {
+      return Promise.reject(new Error('Could not find epinio-server deployment'));
+    }
+
+    if (deployments?.data.length > 1) {
+      return Promise.reject(new Error('Found too many epinio-server deployments'));
+    }
+
+    return deployments.data[0].metadata.namespace;
+  }
+}
+
+const epinioDiscovery = new EpinioDiscovery();
+
+export default epinioDiscovery;


### PR DESCRIPTION
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #322
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Epinio can be installed to namespaces other than `epinio`
- This PR remove's the hardcoding to `epinio` and discovers it instead by ns of the epinio-server pod
- Also
  -  Make home page link to cluster explorer's home page into a true anchor
  - Add a link to take user from an epinio application to cluster explorers deployment detail page

### Areas or cases that should be tested
- Embedded world - Discovery of epinio instances 
- Embedded world - Metrics link on home page
- Embedded world - Link from App to Explorer Deployment Detail page

