### PR TITLE
Fix the about page

### DIFF
--- a/dashboard/pkg/epinio/config/epinio.ts
+++ b/dashboard/pkg/epinio/config/epinio.ts
@@ -117,6 +117,7 @@ export function init($plugin: any, store: any) {
   // Groups
   const ADVANCED_GROUP = 'Advanced';
   const SERVICE_GROUP = 'Services';
+  const ABOUT = 'System';
 
   // Service Instance
   configureType(EPINIO_TYPES.SERVICE_INSTANCE, {
@@ -149,6 +150,15 @@ export function init($plugin: any, store: any) {
     showListMasthead: false // Disable default masthead because we provide a custom one.
   });
 
+  virtualType({
+    label:      store.getters['i18n/t']('epinio.intro.about'),
+    icon:       'dashboard',
+    // group:      'Root',
+    namespaced: false,
+    name:       EPINIO_TYPES.ABOUT,
+    route:      createEpinioRoute('c-cluster-about', { })
+  });
+
   // Side Nav
   weightType(EPINIO_TYPES.CATALOG_SERVICE, 150, true);
   weightType(EPINIO_TYPES.SERVICE_INSTANCE, 151, true);
@@ -164,17 +174,23 @@ export function init($plugin: any, store: any) {
     EPINIO_TYPES.APP_CHARTS
   ], ADVANCED_GROUP);
 
+  basicType([
+    EPINIO_TYPES.ABOUT
+  ], ABOUT);
+
   weightType(EPINIO_TYPES.DASHBOARD, 300, true);
   weightType(EPINIO_TYPES.APP, 250, true);
-  weightGroup(SERVICE_GROUP, 2, true);
   weightType(EPINIO_TYPES.NAMESPACE, 100, true);
-  weightGroup(ADVANCED_GROUP, 1, true);
+  weightGroup(SERVICE_GROUP, 30, true);
+  weightGroup(ADVANCED_GROUP, 20, true);
+  weightGroup(ABOUT, 10, false);
   basicType([
     EPINIO_TYPES.DASHBOARD,
     EPINIO_TYPES.APP,
-    SERVICE_GROUP,
     EPINIO_TYPES.NAMESPACE,
-    ADVANCED_GROUP
+    SERVICE_GROUP,
+    ADVANCED_GROUP,
+    ABOUT
   ]);
 
   headers(EPINIO_TYPES.APP, [

--- a/dashboard/pkg/epinio/pages/c/_cluster/about.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/about.vue
@@ -4,7 +4,6 @@ import { getVendor } from '@shell/config/private-label';
 
 export default {
   async fetch() {
-    debugger;
     this.settings = await this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.SETTING });
 
     this.version = await this.$store.dispatch('epinio/version');

--- a/dashboard/pkg/epinio/pages/c/_cluster/about.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/about.vue
@@ -1,14 +1,10 @@
 <script>
 import { MANAGEMENT } from '@shell/config/types';
 import { getVendor } from '@shell/config/private-label';
-import BackLink from '@shell/components/BackLink';
-import BackRoute from '@shell/mixins/back-link';
 
 export default {
-  layout:     'plain',
-  components: { BackLink },
-  mixins:     [BackRoute],
   async fetch() {
+    debugger;
     this.settings = await this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.SETTING });
 
     this.version = await this.$store.dispatch('epinio/version');
@@ -19,7 +15,9 @@ export default {
   },
   computed: {
     appName() {
-      return getVendor();
+      const isSingleProduct = !!this.$store.getters['isSingleProduct'];
+
+      return isSingleProduct ? getVendor() : this.t('epinio.label');
     },
 
     downloads() {
@@ -60,7 +58,6 @@ export default {
 <template>
   <div class="about">
     <template>
-      <BackLink :link="backLink" />
       <h1 v-t="'about.title'">
         {{ appName }}
       </h1>

--- a/dashboard/pkg/epinio/types.ts
+++ b/dashboard/pkg/epinio/types.ts
@@ -21,6 +21,7 @@ export const EPINIO_TYPES = {
   SERVICE_INSTANCE: 'services',
   // Internal
   DASHBOARD:        'dashboard',
+  ABOUT:            'about',
   CLUSTER:          'cluster',
   APP_ACTION:       'application-action',
   APP_INSTANCE:     'application-instance',


### PR DESCRIPTION


<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #309
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- previously header icon and link text were rancher based
- fix the header by moving the about page to side nav
  - previously this used the `plain` layout
  - the plain layout has a hardcoded rancher image (except in standalone mode)
  - for simplicity just change the about page to a default layout, which means it goes in side nav
  - annoying this needs to be in a side nav group, otherwise menu item appears above service and advanced groups
- fix link text by avoiding getVendor when not in standalone

### Areas or cases that should be tested
- about page in embedded / ui extension world
- about page in standalone world

### Screenshot/Video
![image](https://github.com/epinio/ui/assets/18697775/605ea7fc-1b71-4e1a-94be-26868bb96519)