### PR TITLE
Add install/uninstall buttons to clusters in the cluster list 

### DIFF
--- a/dashboard/pkg/epinio/config/epinio.ts
+++ b/dashboard/pkg/epinio/config/epinio.ts
@@ -300,12 +300,6 @@ export function init($plugin: any, store: any) {
       labelKey: 'epinio.instances.tableHeaders.api',
       sort:     ['api'],
     },
-    {
-      name:     'rancherCluster',
-      labelKey: 'epinio.instances.tableHeaders.cluster',
-      sort:     ['mgmtCluster.nameDisplay'],
-      value:    'mgmtCluster.nameDisplay'
-    },
   ]);
 
   headers(EPINIO_TYPES.CONFIGURATION, [

--- a/dashboard/pkg/epinio/config/epinio.ts
+++ b/dashboard/pkg/epinio/config/epinio.ts
@@ -300,6 +300,12 @@ export function init($plugin: any, store: any) {
       labelKey: 'epinio.instances.tableHeaders.api',
       sort:     ['api'],
     },
+    {
+      name:     'rancherCluster',
+      labelKey: 'epinio.instances.tableHeaders.cluster',
+      sort:     ['mgmtCluster.nameDisplay'],
+      value:    'mgmtCluster.nameDisplay'
+    },
   ]);
 
   headers(EPINIO_TYPES.CONFIGURATION, [

--- a/dashboard/pkg/epinio/l10n/en-us.yaml
+++ b/dashboard/pkg/epinio/l10n/en-us.yaml
@@ -95,8 +95,7 @@ epinio:
   instances:
     header: Epinio instances
     none:
-      header: No instances of Epinio were found
-      description: To view an Epinio cluster be sure to import a Cluster where one is installed
+      description: No instances were found<br><br>Epinio can be installed to known clusters using the action menu to the right of the cluster
     tableHeaders:
       api: URL
       version: Version

--- a/dashboard/pkg/epinio/models/cluster.ts
+++ b/dashboard/pkg/epinio/models/cluster.ts
@@ -51,7 +51,6 @@ export default class EpinioCluster extends Resource {
       // Can they uninstall?
       // Try to find the installed helm app and check permissions on it
 
-      debugger;
       const url = `/k8s/clusters/${ data.mgmtCluster.id }/v1/catalog.cattle.io.apps/${ data.namespace }/${ defaultEpinioChart.name }?exclude=metadata.managedFields`;
 
       ctx.$dispatch(`cluster/request`, { url }, { root: true })

--- a/dashboard/pkg/epinio/models/cluster.ts
+++ b/dashboard/pkg/epinio/models/cluster.ts
@@ -2,8 +2,16 @@ import Resource from '@shell/plugins/dashboard-store/resource-class';
 import { EPINIO_TYPES } from '../types';
 import epinioAuth, { EpinioAuthConfig, EpinioAuthLocalConfig, EpinioAuthTypes } from '../utils/auth';
 import { dashboardUrl } from '../utils/embedded-helpers';
+import { NAME as APP } from '@shell/config/product/apps';
+import { CATALOG } from '@shell/config/types';
+import Vue from 'vue';
 
 export const EpinioInfoPath = `/api/v1/info`;
+
+const defaultEpinioChart = {
+  repo: 'rancher-charts',
+  name: 'epinio',
+};
 
 export default class EpinioCluster extends Resource {
   type = EPINIO_TYPES.CLUSTER;
@@ -17,6 +25,9 @@ export default class EpinioCluster extends Resource {
   api: string;
   mgmtCluster: any;
   oidcEnabled: boolean = false;
+  installed: boolean = false;
+  canInstall: boolean = false;
+  canUninstall: boolean = false;
 
   constructor(data: {
     id: string,
@@ -25,6 +36,7 @@ export default class EpinioCluster extends Resource {
     loggedIn: boolean,
     api: string,
     mgmtCluster: any,
+    installed: boolean,
   }, ctx: any) {
     super(data, ctx);
     this.id = data.id;
@@ -33,18 +45,74 @@ export default class EpinioCluster extends Resource {
     this.api = data.api;
     this.loggedIn = data.loggedIn;
     this.mgmtCluster = data.mgmtCluster;
+    this.installed = data.installed;
+
+    if (this.installed) {
+      // Can they uninstall?
+      // Try to find the installed helm app and check permissions on it
+
+      debugger;
+      const url = `/k8s/clusters/${ data.mgmtCluster.id }/v1/catalog.cattle.io.apps/${ data.namespace }/${ defaultEpinioChart.name }?exclude=metadata.managedFields`;
+
+      ctx.$dispatch(`cluster/request`, { url }, { root: true })
+        .then((app: any) => {
+          Vue.set(this, 'canUninstall', !!app?.actions?.uninstall);
+        })
+        .catch(() => {
+          Vue.set(this, 'canUninstall', false);
+        });
+    } else {
+      // Can they install?
+
+      // Can they install charts in target repo
+      const url = `/k8s/clusters/${ data.mgmtCluster.id }/v1/catalog.cattle.io.clusterrepos/${ defaultEpinioChart.repo }?exclude=metadata.managedFields`;
+
+      ctx.$dispatch(`cluster/request`, { url }, { root: true })
+        .then((repo: any) => {
+          Vue.set(this, 'canInstall', !!repo?.actions?.install);
+        })
+        .catch(() => {
+          Vue.set(this, 'canInstall', false);
+        });
+
+      // Ideally we would also check if they can see the target chart to install, but lets go on the assumption epinio app will always be there
+    }
   }
 
   get availableActions() {
-    return [
-      {
+    const actions: any[] = [];
+
+    if (this.loggedIn) {
+      actions.push({
         action:   'logOut',
-        enabled:  this.loggedIn,
         icon:     'icon icon-fw icon-chevron-right',
         label:    this.t('nav.userMenu.logOut'),
         disabled: false,
-      },
-    ];
+      });
+
+      actions.push({ divider: true });
+    }
+
+    if (this.installed) {
+      if (this.canUninstall) {
+        actions.push({
+          action: 'uninstall',
+          icon:   'icon icon-fw icon-minus',
+          label:  this.t('asyncButton.uninstall.action'),
+        });
+      }
+    } else {
+      if (this.canInstall) {
+        actions.push({
+          action:   'install',
+          icon:     'icon icon-fw icon-plus',
+          label:    this.t('asyncButton.install.action'),
+          disabled: !this.canInstall,
+        });
+      }
+    }
+
+    return actions;
   }
 
   get infoUrl() {
@@ -81,5 +149,34 @@ export default class EpinioCluster extends Resource {
     };
 
     return config;
+  }
+
+  install() {
+    // Take them to the default helm chart's detail page
+    this.currentRouter().push({
+      name:   `c-cluster-apps-charts-chart`,
+      params: {
+        product: APP,
+        cluster: this.mgmtCluster.id,
+      },
+      query: {
+        'repo-type': 'cluster',
+        repo:        defaultEpinioChart.repo,
+        chart:       defaultEpinioChart.name,
+      }
+    });
+  }
+
+  uninstall() {
+    // Uninstall is an action from the apps list, so do our best to get the user there
+    this.currentRouter().push({
+      name:   `c-cluster-product-resource`,
+      params: {
+        product:  APP,
+        cluster:  this.mgmtCluster.id,
+        resource: CATALOG.APP,
+      },
+      query: { q: defaultEpinioChart.name }
+    });
   }
 }

--- a/dashboard/pkg/epinio/package.json
+++ b/dashboard/pkg/epinio/package.json
@@ -2,7 +2,7 @@
   "name": "epinio",
   "description": "Application Development Engine for Kubernetes",
   "icon": "https://raw.githubusercontent.com/rancher/dashboard/0b6cbe93e9ed3292294da178f119a500cc494db9/pkg/epinio/assets/logo-epinio.svg",
-  "version": "1.11.0-2",
+  "version": "1.11.0-3",
   "private": false,
   "rancher": true,
   "license": "Apache-2.0",

--- a/dashboard/pkg/epinio/pages/index.vue
+++ b/dashboard/pkg/epinio/pages/index.vue
@@ -208,6 +208,15 @@ export default Vue.extend<Data, any, any, any>({
             </template>
           </div>
         </template>
+        <template #cell:rancherCluster="{row}">
+          <div class="epinio-row">
+            <nuxt-link
+              :to="{ name: 'c-cluster-explorer', params: { cluster: row.id } }"
+            >
+              {{ row.nameDisplay }}
+            </nuxt-link>
+          </div>
+        </template>
       </ResourceTable>
     </div>
     <Dialog

--- a/dashboard/pkg/epinio/utils/epinio-discovery.ts
+++ b/dashboard/pkg/epinio/utils/epinio-discovery.ts
@@ -37,10 +37,19 @@ class EpinioDiscovery {
           namespace,
           api:         url,
           loggedIn:    !!loggedIn,
-          mgmtCluster: c
-        }, { rootGetters: store.getters }));
+          mgmtCluster: c,
+          installed:   true,
+        }, { rootGetters: store.getters, $dispatch: store.dispatch }));
       } catch (err) {
-        console.debug(`Skipping epinio discovery for ${ c.spec.displayName }:`, err); // eslint-disable-line no-console
+        epinioClusters.push(new EpinioCluster({
+          id:          c.id,
+          name:        c.spec.displayName,
+          namespace:   '',
+          api:         '',
+          loggedIn:    false,
+          mgmtCluster: c,
+          installed:   false,
+        }, { rootGetters: store.getters, $dispatch: store.dispatch }));
       }
     }
 


### PR DESCRIPTION
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #367



### Occurred changes and/or fixed issues
- Enhance the initial experience of the ui-extension by guiding the user to install epinio on clusters that we can't find it on
  - for clusters which we've found epinio on... and they can... show uninstall action
  - for cluster with no epinio on... and they can... show install button


### Technical notes summary
- In order to do this we now show all clusters in the list, instead of just those that have epinio installed
- Blocked on #364

### Areas or cases that should be tested
- install action leads user to the cluster's epinio chart detail page
- uninstall action leads users to cluster's helm app page with the query string "epinio"
- when there are no epinio instances detected we show a nice intro guiding to install action



### Screenshot/Video
![Screenshot_20231127_100958](https://github.com/epinio/ui/assets/18697775/efc845ec-4375-4fd5-af9b-097bcd85c6ad)

