### PR TITLE
Update dashboard-build-extension.yml

### DIFF
--- a/.github/workflows/dashboard-build-extension.yml
+++ b/.github/workflows/dashboard-build-extension.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           cache: yarn
           node-version-file: '.nvmrc'
+          cache-dependency-path: dashboard/yarn.lock
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
Added workflow attribute to point to the yarn.lock in the extension directory. 