### PR TITLE
fix: Remove save attribute that shows double cancel/save :

### DIFF
--- a/dashboard/pkg/epinio/edit/applications.vue
+++ b/dashboard/pkg/epinio/edit/applications.vue
@@ -75,7 +75,7 @@ onMounted(async () => {
 });
 
 const shouldShowButtons = computed(
-  () => (store.$router.currentRoute._value.hash === '#source' ? 'hide-buttons-deploy' : '')
+  () => (store.$router.currentRoute.value.hash === '#source' ? 'hide-buttons-deploy' : '')
 );
 const showSourceTab = computed(() => {
   return props.mode === _EDIT
@@ -185,6 +185,7 @@ function validate(value: boolean, tab: string) {
     :errors="errors"
     :validation-passed="validationPassed"
     @error="(e : Error) => errors = epinioExceptionToErrorsArray(e)"
+    @finish="save"
   >
     <ResourceTabs
       mode="mode"

--- a/dashboard/pkg/epinio/edit/applications.vue
+++ b/dashboard/pkg/epinio/edit/applications.vue
@@ -185,7 +185,6 @@ function validate(value: boolean, tab: string) {
     :errors="errors"
     :validation-passed="validationPassed"
     @error="(e : Error) => errors = epinioExceptionToErrorsArray(e)"
-    @finish="save"
   >
     <ResourceTabs
       mode="mode"


### PR DESCRIPTION
### Summary
Fixes the double cancel/save actions in the edit application view. 

### Areas or cases that should be tested
Edit any application and use the "Update Source" button to save the app. There should be no default cancel/save buttons. 

### Screenshot/Video
![image](https://github.com/user-attachments/assets/d0dbe4ee-07a3-4c92-96ee-9443a6548ecc)
![image](https://github.com/user-attachments/assets/ed8ac1da-98e8-4504-ac5a-a5627c4db73d)
