### PR TITLE
fix: Use norman cluster instead of resource: In addition to the model…

### DIFF
--- a/dashboard/pkg/epinio/models/cluster.js
+++ b/dashboard/pkg/epinio/models/cluster.js
@@ -1,39 +1,24 @@
-import Resource from '@shell/plugins/dashboard-store/resource-class';
+import NormanCluster from '@shell/models/cluster';
 import { EPINIO_TYPES } from '../types';
-import epinioAuth, { EpinioAuthConfig, EpinioAuthLocalConfig, EpinioAuthTypes } from '../utils/auth';
+import epinioAuth, { EpinioAuthTypes } from '../utils/auth';
 import { dashboardUrl } from '../utils/embedded-helpers';
 
 export const EpinioInfoPath = `/api/v1/info`;
 
-export default class EpinioCluster extends Resource {
-  type = EPINIO_TYPES.CLUSTER;
-
-  id: string;
-  name: string;
-  namespace: string;
-  state?: string;
-  metadata?: { state: { transitioning: boolean, error: boolean, message: string }};
-  loggedIn: boolean;
-  api: string;
-  mgmtCluster: any;
-  version?: string;
-  oidcEnabled: boolean = false;
-
-  constructor(data: {
-    id: string,
-    name: string,
-    namespace: string,
-    loggedIn: boolean,
-    api: string,
-    mgmtCluster: any,
-  }, ctx: any) {
+export default class EpinioCluster extends NormanCluster {
+  constructor(data, ctx) {
     super(data, ctx);
+    this.type = EPINIO_TYPES.CLUSTER;
     this.id = data.id;
     this.name = data.name;
     this.namespace = data.namespace;
     this.api = data.api;
     this.loggedIn = data.loggedIn;
     this.mgmtCluster = data.mgmtCluster;
+    this.state = undefined;
+    this.metadata = undefined;
+    this.version = undefined;
+    this.oidcEnabled = false;
   }
 
   get availableActions() {
@@ -70,8 +55,8 @@ export default class EpinioCluster extends Resource {
     }
   }
 
-  createAuthConfig(type: EpinioAuthTypes, localConfig?: EpinioAuthLocalConfig): EpinioAuthConfig {
-    const config: EpinioAuthConfig = {
+  createAuthConfig(type, localConfig) {
+    const config = {
       type,
       epinioUrl: this.api,
       dexConfig: {


### PR DESCRIPTION
… type change, the file was converted back to js to mitigate ts import errors

<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #441 - The cluster extension was using the resource model instead of the cluster model. That caused the cluster model to not have newly added functions. There was also issues with compatibility between typescript and javascript so the model was reverted to javascript. 

### Occurred changes and/or fixed issues
- Renamed/converted models/cluster.ts to cluster.js

### Areas or cases that should be tested
- Via developer load, test to make sure you can log in and reach the dashboard page within the extension. 
- Go to cluster management, import cluster, and try to import a generic cluster. It should complete with no error. 