### PR TITLE
Fix Application Create Button

### DIFF
--- a/dashboard/pkg/epinio/pages/c/_cluster/applications/createapp/index.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/applications/createapp/index.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ref, reactive, onBeforeMount, computed } from 'vue';
-import { useRouter } from 'vue-router';
 import { useStore } from 'vuex';
 import Loading from '@shell/components/Loading.vue';
 import Wizard from '@shell/components/Wizard.vue';
@@ -15,7 +14,6 @@ import { EpinioAppInfo, EpinioAppBindings, EpinioAppSource, EPINIO_TYPES } from 
 import { createEpinioRoute } from '../../../../../utils/custom-routing';
 import { allHash } from '@shell/utils/promise';
 
-const router = useRouter();
 const store = useStore();
 
 const loading = ref(true);
@@ -131,7 +129,7 @@ function updateConfigurations(changes: EpinioAppBindings) {
 }
 
 function cancel() {
-  router.replace(value.value.listLocation);
+  store.$router.replace(value.value.listLocation);
 }
 
 function finish() {
@@ -141,7 +139,7 @@ function finish() {
     id: `${value.value.meta.namespace}/${value.value.meta.name}`
   });
 
-  router.replace(route);
+  store.$router.replace(route);
 }
 </script>
 

--- a/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
 import { useStore } from 'vuex';
-import { useRouter } from 'vue-router';
 
 import ResourceTable from '@shell/components/ResourceTable';
 import Loading from '@shell/components/Loading';
@@ -12,7 +11,6 @@ import { EPINIO_TYPES } from '../../../../types';
 import { createEpinioRoute } from '../../../../utils/custom-routing';
 
 const store = useStore();
-const router = useRouter();
 
 const resource = EPINIO_TYPES.APP;
 const schema = ref(store.getters['epinio/schemaFor'](resource));
@@ -24,7 +22,7 @@ const createLocation = computed(() =>
 );
 
 const openCreateRoute = () => {
-  router.push(createLocation.value);
+  store.$router.push(createLocation.value);
 };
 
 const rows = computed(() => store.getters['epinio/all'](resource));


### PR DESCRIPTION
### Summary
- Fixes Application create button not working. 

### Technical notes summary
- The router was not updated to use the store referenced router. 

### Areas or cases that should be tested
- Click the button on the application create screen, and it should route you to the initial step of creating an application. 