### PR TITLE
Add Metrics Report Download Button

### DIFF
--- a/dashboard/pkg/epinio/components/application/AppInfo.vue
+++ b/dashboard/pkg/epinio/components/application/AppInfo.vue
@@ -241,7 +241,6 @@ const moveBooleansToFront = (settingsObj: any) => {
   <Loading v-if="!values" />
   <div v-else>
     <div class="col">
-      Test
       <NameNsDescription
         data-testid="epinio_app-info_name-ns"
         :namespaces-override="namespaceNames"

--- a/dashboard/pkg/epinio/l10n/en-us.yaml
+++ b/dashboard/pkg/epinio/l10n/en-us.yaml
@@ -65,6 +65,13 @@ epinio:
   about:
     allPackages: See all packages
     getBinaries: Get binaries
+  downloadReport:
+    title: Download report
+    action: Download Report
+    success: Report downloaded successfully
+    errors:
+      unauthorized: You need admin permissions to download the report
+      failed: Failed to download report. Please try again or contact support
   supportBundle:
     title: Download support bundle
     description: Collect a troubleshooting bundle for support.

--- a/dashboard/pkg/epinio/l10n/en-us.yaml
+++ b/dashboard/pkg/epinio/l10n/en-us.yaml
@@ -66,20 +66,20 @@ epinio:
     allPackages: See all packages
     getBinaries: Get binaries
   downloadReport:
-    title: Download report
-    action: Download Report
-    success: Report downloaded successfully
+    title: Cluster Metrics Report
+    action: Download
+    success: Metrics report downloaded successfully
     errors:
       unauthorized: You need admin permissions to download the report
       failed: Failed to download report. Please try again or contact support
   supportBundle:
-    title: Download support bundle
+    title: Download Support Bundle
     description: Collect a troubleshooting bundle for support.
     tail:
       label: Log lines per component
       help: Defaults to 1000 lines. Maximum 10000.
     includeApps: Include application logs
-    action: Download Support Bundle
+    action: Download
     collecting: Collecting logs from Epinio components...
     success: Support bundle downloaded successfully
     errors:


### PR DESCRIPTION
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Adds Metrics Report Button to about page. 

### Occurred changes and/or fixed issues
Button and functionality to trigger the metrics report to be generated and downloaded. 

### Areas or cases that should be tested
Check to make sure the file is being downloaded properly.