### PR TITLE
Image validation

### DIFF
--- a/dashboard/pkg/epinio/components/application/AppSource.vue
+++ b/dashboard/pkg/epinio/components/application/AppSource.vue
@@ -100,6 +100,13 @@ const builderImage = reactive({
   default: builderImageValue.value === defaultBuilderImage.value
 });
 
+// Builder image validation (debounced API)
+type ValidationStatus = 'idle' | 'validating' | 'valid' | 'invalid';
+const builderImageValidationStatus = ref<ValidationStatus>('idle');
+const builderImageValidationError = ref('');
+const builderImageValidationSuggestion = ref('');
+let builderImageValidationTimeout: ReturnType<typeof setTimeout> | null = null;
+
 const EDIT = _EDIT;
 
 const appChart = ref(props.source?.appChart);
@@ -146,7 +153,31 @@ watch(valid, (val) => {
   emit('valid', val);
 });
 
+watch(
+  () => ({ value: builderImage.value, default: builderImage.default }),
+  (curr, prev) => {
+    if (curr.default) {
+      clearBuilderImageValidation();
+      update();
+      return;
+    }
+    if ((curr.value || '').trim() === '') {
+      clearBuilderImageValidation();
+      update();
+      return;
+    }
+    if (curr.value !== prev?.value || curr.default !== prev?.default) {
+      scheduleBuilderImageValidation();
+    }
+  },
+  { deep: true }
+);
+
 function validate() {
+  const builderImageInvalid = showBuilderImage.value && !builderImage.default && builderImageValidationStatus.value === 'invalid';
+  if (builderImageInvalid) {
+    return false;
+  }
   switch (type.value) {
     case APPLICATION_SOURCE_TYPE.ARCHIVE:
     case APPLICATION_SOURCE_TYPE.FOLDER:
@@ -182,9 +213,81 @@ function updateConfigurations(configs: string[]) {
   emit('changeAppConfig', configs);
 }
 
+function clearBuilderImageValidation() {
+  builderImageValidationStatus.value = 'idle';
+  builderImageValidationError.value = '';
+  builderImageValidationSuggestion.value = '';
+  if (builderImageValidationTimeout !== null) {
+    clearTimeout(builderImageValidationTimeout);
+    builderImageValidationTimeout = null;
+  }
+}
+
+async function validateBuilderImageApi(image: string) {
+  try {
+    const res = await store.dispatch('epinio/request', {
+      opt: {
+        url:    `/api/v1/validate-builder-image?image=${ encodeURIComponent(image) }`,
+        method: 'get'
+      },
+      growlOnError: false
+    });
+    const data = res?.data || {};
+    if (data.valid === true) {
+      builderImageValidationStatus.value = 'valid';
+      builderImageValidationError.value = '';
+      builderImageValidationSuggestion.value = '';
+    } else {
+      builderImageValidationStatus.value = 'invalid';
+      builderImageValidationError.value = data.message || t('epinio.applications.steps.source.archive.builderimage.validationError');
+      builderImageValidationSuggestion.value = data.suggestion || '';
+    }
+    update();
+  } catch (err: any) {
+    const res = err?.response || err?.data;
+    const bodyMessage = res?.data?.message;
+    builderImageValidationStatus.value = 'invalid';
+    builderImageValidationError.value = bodyMessage || t('epinio.applications.steps.source.archive.builderimage.validationNetworkError');
+    builderImageValidationSuggestion.value = '';
+    update();
+  }
+}
+
+function scheduleBuilderImageValidation() {
+  if (builderImageValidationTimeout !== null) {
+    clearTimeout(builderImageValidationTimeout);
+    builderImageValidationTimeout = null;
+  }
+  const value = (builderImage.value || '').trim();
+  if (builderImage.default) {
+    clearBuilderImageValidation();
+    update();
+    return;
+  }
+  if (!value) {
+    clearBuilderImageValidation();
+    update();
+    return;
+  }
+  builderImageValidationStatus.value = 'validating';
+  builderImageValidationError.value = '';
+  builderImageValidationSuggestion.value = '';
+  builderImageValidationTimeout = setTimeout(() => {
+    builderImageValidationTimeout = null;
+    validateBuilderImageApi(value);
+  }, 500);
+}
+
+function builderImageRule() {
+  if (builderImageValidationStatus.value === 'invalid' && builderImageValidationError.value) {
+    return builderImageValidationError.value;
+  }
+}
+
 function onImageType(defaultImage: boolean) {
   if (defaultImage) {
     builderImage.value = defaultBuilderImage.value;
+    clearBuilderImageValidation();
   } else {
     builderImage.value = builderImageValue.value;
   }
@@ -476,14 +579,42 @@ onMounted(() => {
           :label-key="'epinio.applications.steps.source.archive.builderimage.label'"
           @update:value="onImageType"
         />
-        <LabeledInput
-          v-model:value="builderImage.value"
-          data-testid="epinio_app-source_builder-value"
-          :disabled="builderImage.default"
-          :tooltip="t('epinio.applications.steps.source.archive.builderimage.tooltip')"
-          :mode="mode"
-          @input="update"
-        />
+        <div class="builder-image-input-wrap">
+          <LabeledInput
+            v-model:value="builderImage.value"
+            data-testid="epinio_app-source_builder-value"
+            :disabled="builderImage.default"
+            :tooltip="t('epinio.applications.steps.source.archive.builderimage.tooltip')"
+            :mode="mode"
+            :rules="[builderImageRule]"
+            :aria-invalid="builderImageValidationStatus === 'invalid'"
+            :aria-describedby="(builderImageValidationStatus === 'validating' || builderImageValidationStatus === 'valid') ? 'builder-image-validation-msg' : (builderImageValidationSuggestion ? 'builder-image-validation-suggestion' : undefined)"
+            @input="update"
+          />
+          <p
+            v-if="builderImageValidationStatus === 'validating'"
+            id="builder-image-validation-msg"
+            class="builder-image-validation validating"
+            role="status"
+          >
+            {{ t('epinio.applications.steps.source.archive.builderimage.validating') }}
+          </p>
+          <p
+            v-else-if="builderImageValidationStatus === 'valid'"
+            id="builder-image-validation-msg"
+            class="builder-image-validation valid"
+            role="status"
+          >
+            {{ t('epinio.applications.steps.source.archive.builderimage.valid') }}
+          </p>
+          <p
+            v-else-if="builderImageValidationSuggestion"
+            id="builder-image-validation-suggestion"
+            class="builder-image-validation suggestion"
+          >
+            {{ builderImageValidationSuggestion }}
+          </p>
+        </div>
       </template>
     </Collapse>
   </div>
@@ -514,5 +645,25 @@ onMounted(() => {
 .archive {
   display: flex;
   flex-direction: column;
+}
+
+.builder-image-input-wrap {
+  .builder-image-validation {
+    margin: 4px 0 0;
+    font-size: 12px;
+
+    &.validating {
+      color: var(--input-label);
+    }
+
+    &.valid {
+      color: var(--success);
+    }
+
+    &.suggestion {
+      color: var(--input-label);
+      font-style: italic;
+    }
+  }
 }
 </style>

--- a/dashboard/pkg/epinio/components/application/AppSource.vue
+++ b/dashboard/pkg/epinio/components/application/AppSource.vue
@@ -263,12 +263,12 @@ async function validateBuilderImageApi(image: string) {
       return;
     }
     const status = res?.status;
-    const bodyMessage = res?.data?.message;
+    const apiErrorMessage = res?.data?.errors?.[0]?.title || res?.data?.errors?.[0]?.details || res?.data?.message;
     builderImageValidationStatus.value = 'invalid';
     if (status === 401 || status === 403) {
-      builderImageValidationError.value = bodyMessage || t('epinio.applications.steps.source.archive.builderimage.validationAuthError');
+      builderImageValidationError.value = apiErrorMessage || t('epinio.applications.steps.source.archive.builderimage.validationAuthError');
     } else {
-      builderImageValidationError.value = bodyMessage || t('epinio.applications.steps.source.archive.builderimage.validationNetworkError');
+      builderImageValidationError.value = apiErrorMessage || t('epinio.applications.steps.source.archive.builderimage.validationNetworkError');
     }
     builderImageValidationSuggestion.value = '';
     update();

--- a/dashboard/pkg/epinio/l10n/en-us.yaml
+++ b/dashboard/pkg/epinio/l10n/en-us.yaml
@@ -230,6 +230,10 @@ epinio:
             tooltip: Paketo builder image to use for staging
             default: Default Image
             custom: Custom Image
+            validating: Validating…
+            valid: Valid builder image
+            validationError: Invalid builder image
+            validationNetworkError: Could not validate builder image. Check your connection.
           appchart:
             label: Application Chart
         container_url:

--- a/dashboard/pkg/epinio/l10n/en-us.yaml
+++ b/dashboard/pkg/epinio/l10n/en-us.yaml
@@ -234,6 +234,7 @@ epinio:
             valid: Valid builder image
             validationError: Invalid builder image
             validationNetworkError: Could not validate builder image. Check your connection.
+            validationAuthError: Could not validate. Sign in again.
           appchart:
             label: Application Chart
         container_url:


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
Adds validation for the Paketo Builder Image field in the application source form: the UI calls the Epinio API to validate the builder image before staging. Shows real-time feedback (valid / invalid / validating) and handles auth failures and stale responses.

### Occurred changes and/or fixed issues
Custom input for “Paketo Builder Image” with 500ms debounced calls to GET /api/v1/validate-builder-image?image=<value>.
Validation states: “Validating…”, valid (green), invalid (red with message/suggestion), and auth error (“Could not validate. Sign in again.”).

### Technical notes summary
The Epinio backend exposes GET /api/v1/validate-builder-image?image=<image> (format + optional registry check). The UI does not call the new buildpack search/verify APIs; those are for future buildpack selection/validation.
Store returns the API response on the body (with _status), not as { data, status }. The handler uses body._status, body.valid, body.message, body.suggestion and always clears the validating state on completion.
Debounce (500ms) limits API calls while the user types. Only the latest request’s result is applied; older responses are ignored when (builderImage.value || '').trim() !== image.

### Areas or cases that should be tested
Happy path:
Open Create/Edit Application → Source (e.g. buildpacks, custom builder).
In “Paketo Builder Image”, enter a valid image (e.g. paketobuildpacks/builder:full).
After ~500ms, “Validating…” appears, then a valid state (e.g. green check).

Invalid image:
Enter an invalid or non-existent image (e.g. invalid/bogus:latest).
After validation, invalid state and message/suggestion are shown.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
