### PR TITLE
fix(Changed how chart values are handled and passed to the parent com…

### DIFF
--- a/dashboard/pkg/epinio/components/settings/ChartValues.vue
+++ b/dashboard/pkg/epinio/components/settings/ChartValues.vue
@@ -92,7 +92,7 @@ const onInputCheckbox = (key: string, value: boolean) => {
         :label="key"
         :mode="props.mode"
         :disabled="props.disabled"
-        @input="onInputCheckbox(key, $event)"
+        @update:value="onInputCheckbox(key, $event)"
       />
       <LabeledSelect
         v-else-if="setting.type === 'string' && setting.enum"

--- a/dashboard/pkg/epinio/edit/services.vue
+++ b/dashboard/pkg/epinio/edit/services.vue
@@ -49,7 +49,7 @@ const errors = ref<Array<string>>([]);
 const doneParams = reactive<object>({});
 const validChartValues = ref<object>({});
 const failedWaitingForServiceInstance = ref<boolean>(false);
-const chartValues = reactive<ChartValues>(objValuesToString(props.value?.settings) || {});
+const chartValues = reactive<Record<string, any>>(objValuesToString(props.value?.settings) || {});
 
 onMounted(async () => {
   await Promise.all([
@@ -204,7 +204,9 @@ const save = async (saveCb: (success: boolean) => void) => {
   );
 
   if (newSettings) {
-    props.value.settings = objValuesToString(chartValues.value);
+    const cleanSettings = { ...chartValues };
+    delete cleanSettings.value;
+    props.value.settings = objValuesToString(cleanSettings);
   }else{
     props.value.settings = undefined;
   }
@@ -212,9 +214,11 @@ const save = async (saveCb: (success: boolean) => void) => {
   try {
     if (!isEdit.value) {
       await props.value.create();
+
       if (selectedApps.value.length) {
         await updateServiceInstanceAppBindings(props.value);
       }
+
       await store.dispatch(
         'epinio/findAll',
         { type: props.value.type, opt: { force: true }},
@@ -229,6 +233,7 @@ const save = async (saveCb: (success: boolean) => void) => {
       if (newSettings) {
         await props.value.update();
       }
+
       await updateServiceInstanceAppBindings(props.value);
       await props.value.forceFetch();
 

--- a/dashboard/pkg/epinio/edit/services.vue
+++ b/dashboard/pkg/epinio/edit/services.vue
@@ -204,6 +204,8 @@ const save = async (saveCb: (success: boolean) => void) => {
   );
 
   if (newSettings) {
+    /*Temporary fix until we can update the reactiveness of ChartValues, delete
+    auto inserted value prop.*/
     const cleanSettings = { ...chartValues };
     delete cleanSettings.value;
     props.value.settings = objValuesToString(cleanSettings);


### PR DESCRIPTION
…ponent):

### PR Checklist
- [x] Linting Test is passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes issue with the Chart Values not saving to the service secret. 

### Occurred changes and/or fixed issues
Changed how values are handled in the ChartValues.vue and services.vue.

### Areas or cases that should be tested
- Service Creation (specifically chart values)
- Service Updating (specifically chart values)

### Areas which could experience regressions
- Service Creation/Updating

You will need to have a chart with chart values available to test this, easiest way is to modify an existing service templates/service-catalog.yaml in the helm charts repository. And run helm upgrade on the local chart. `helm upgrade --install epinio ./chart/epinio --namespace epinio --create-namespace --set global.domain=myepiniodomain.org`.

```
settings:
    configServer.checkbox:
      type: bool
    name:
      type: string
    s3Bucket:
      type: string
    myIntSetting:
      type: integer
    mySelectSetting:
      type: string
      enum:
        - option1
        - option2
        - option3
```