### PR TITLE
fix: hide info button in standalone and hide trailhand console warnings

### DIFF
--- a/dashboard/pkg/epinio/index.ts
+++ b/dashboard/pkg/epinio/index.ts
@@ -18,6 +18,15 @@ const epinioObjAnnotations = [
   'epinio.io/created-by'
 ];
 
+// hide warnings related to trailhand components, they are working fine, however we are unable to register them gloabally due to the rancher shell
+const _warn = console.warn; // eslint-disable-line no-console
+console.warn = (...args: any[]) => { // eslint-disable-line no-console
+  if (typeof args[0] === 'string' && args[0].includes('Failed to resolve component: trailhand-')) {
+    return;
+  }
+  _warn(...args);
+};
+
 const isPodFromEpinio = (a: string) => epinioObjAnnotations.includes(a);
 
 const onEnter: OnNavToPackage = async({ getters, dispatch }) => {

--- a/dashboard/pkg/epinio/pages/c/_cluster/dashboard.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/dashboard.vue
@@ -365,7 +365,7 @@ function handleAboutClick() {
         >
         </trailhand-card>
         <trailhand-card
-          v-if="aboutLink"
+          v-if="!store.getters['isSingleProduct']"
           variant="info"
           :card-title="t('epinio.intro.about')"
           clickable

--- a/dashboard/vue.config.js
+++ b/dashboard/vue.config.js
@@ -1,6 +1,22 @@
-const config = require('@rancher/shell/vue.config'); // eslint-disable-line @typescript-eslint/no-var-requires
+const config = require("@rancher/shell/vue.config"); // eslint-disable-line @typescript-eslint/no-var-requires
 
-module.exports = config(__dirname, {
+const baseConfig = config(__dirname, {
   excludes: [],
   // excludes: ['fleet', 'example']
 });
+
+module.exports = {
+  ...baseConfig,
+  chainWebpack: (config) => {
+    config.module
+      .rule("vue")
+      .use("vue-loader")
+      .tap((options) => ({
+        ...options,
+        compilerOptions: {
+          ...(options.compilerOptions || {}),
+          isCustomElement: (tag) => tag.startsWith("trailhand-"),
+        },
+      }));
+  },
+};


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] Code is well documented
- [x] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Hide info button in standalone app (this was previously hidden, but changed by my latest PR, so I am changing it back.
- Hide console warnings relating to trailhand components. Since these are web components, we are having issues registering them globally due to the rancher shell. The components are working fine. Since the long term plan is to move away from the rancher shell, I think it is fine to hide these warnings and clean up the console in the mean time

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested . -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
