### PR TITLE
Fix/epinio namespace check

### DIFF
--- a/dashboard/pkg/epinio/index.ts
+++ b/dashboard/pkg/epinio/index.ts
@@ -88,9 +88,7 @@ export default function(plugin: IPlugin) {
       labelKey: 'epinio.applications.actions.goToEpinio.label',
       icon:     'icon-epinio',
       enabled(ctx: any) {
-        const isUserNamespace = ctx.metadata.namespace !== 'epinio';
-
-        return isUserNamespace && !!Object.keys(ctx.metadata.annotations || []).find((annotation) => isPodFromEpinio(annotation));
+        return !!Object.keys(ctx.metadata.annotations || []).find((annotation) => isPodFromEpinio(annotation));
       },
       invoke(_: ActionOpts, values: any[]) {
         const obj = values[0];


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] Code is well documented
- [x] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
Fixes hardcoded namespace assumptions in the Epinio UI dashboard extension.


### Occurred changes and/or fixed issues
*   Modified `ui/dashboard/pkg/epinio/index.ts` to remove the hardcoded check `ctx.metadata.namespace !== 'epinio'`.
*   The "Go to Epinio" action button logic now relies solely on Epinio-specific annotations (`isPodFromEpinio`) rather than excluding specific namespace names.

### Technical notes summary
*   Previously, the UI explicitly hid the "Go to Epinio" button if a resource was in the `epinio` namespace. This logic was brittle and did not account for custom installation namespaces or edge cases where valid Epinio workloads might exist in the installation namespace.
*   The logic is now namespace-agnostic, checking only if the resource (Pod) has the required Epinio annotations to link back to an application.


### Areas or cases that should be tested
1.  **Custom Namespace Installation:**
    *   Install Epinio in a custom namespace (e.g., `my-custom-ns`).
    *   Deploy a sample application.
    *   Navigate to the Kubernetes Pods list in the Rancher/Epinio dashboard.
    *   Locate the pod for the deployed application.
    *   Verify that the "Go to Epinio" action button is visible and functional.
2.  **Standard Installation (Regression):**
    *   Install Epinio in the default `epinio` namespace.
    *   Deploy an application.
    *   Verify the button still appears correctly for these apps.

### Areas which could experience regressions
*   **Action Button Visibility:** Ensure the button does not start appearing on system components (like Epinio server pods) where it shouldn't, although the `isPodFromEpinio` annotation check should prevent this.


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
