### PR TITLE
show applications table for every namespace when empty

### DIFF
--- a/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
@@ -29,8 +29,10 @@ const openCreateRoute = () => {
 };
 
 const rows = computed(() => store.getters['epinio/all'](resource));
+const allNamespaces = computed(() => store.getters['epinio/all'](EPINIO_TYPES.NAMESPACE) || []);
 
-// Group applications by namespace
+// Group applications by namespace. Include every namespace so the applications table
+// is shown even when a namespace has no applications.
 const groupedByNamespace = computed(() => {
   // Access the cache key to trigger namespace filter changes
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -39,19 +41,31 @@ const groupedByNamespace = computed(() => {
 
   const groups: Record<string, any[]> = {};
 
+  // Determine which namespace names to show (all, or filtered)
+  const showAll = !activeNamespaces || Object.keys(activeNamespaces).length === 0;
+  const namespaceNamesToShow = new Set<string>();
+
+  allNamespaces.value.forEach((ns: any) => {
+    const name = ns.meta?.name || ns.name;
+    if (name && (showAll || activeNamespaces[name])) {
+      namespaceNamesToShow.add(name);
+    }
+  });
+
+  // Initialize every visible namespace with an empty apps array
+  namespaceNamesToShow.forEach((name) => {
+    groups[name] = [];
+  });
+
+  // Assign each application to its namespace group
   rows.value.forEach((app: any) => {
     const namespace = app.meta?.namespace || 'default';
-
-    // Only include this namespace if it's in the active filter
-    // If no filter is active or filter is empty, show all namespaces
-    if (!activeNamespaces || Object.keys(activeNamespaces).length === 0 || activeNamespaces[namespace]) {
-      if (!groups[namespace]) {
-        groups[namespace] = [];
-      }
+    if (namespaceNamesToShow.has(namespace)) {
       groups[namespace].push(app);
     }
   });
 
+  // Fallback when no namespaces are loaded yet
   if (Object.keys(groups).length === 0) {
     groups['workspace'] = [];
   }
@@ -103,6 +117,8 @@ const columns: DataTableColumn[] = [
 
 onMounted(async () => {
   await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.APP });
+  // Ensure namespaces are loaded so we can show the applications table for every namespace (EPINIO-494)
+  await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.NAMESPACE });
   // Non-blocking fetch
   store.dispatch('epinio/findAll', { type: EPINIO_TYPES.CONFIGURATION });
   store.dispatch('epinio/findAll', { type: EPINIO_TYPES.SERVICE_INSTANCE });


### PR DESCRIPTION

### PR Checklist
- [x] Linting Test is passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
Show the applications table for each namespace even when it has no applications, so users can confirm the namespace exists and see a consistent layout.

### Occurred changes and/or fixed issues
1. Applications index grouping: Updated groupedByNamespace on the applications page to build groups from all namespaces (respecting the active namespace filter), not only from namespaces that currently have apps.
2. Empty-namespace tables: Ensured every visible namespace renders an applications DataTable, even when its app list is empty (table shows the standard “No data available” empty state).
3. Data loading: Added a findAll call for namespaces when loading the applications page so namespace data is always available for grouping.
4. UX consistency: Prevents confusion where a user selects/filters to a namespace but sees no applications section and assumes the namespace does not exist.

### Technical notes summary
groupedByNamespace now:
  Reads all namespaces via store.getters['epinio/all'](EPINIO_TYPES.NAMESPACE).
  Derives the set of namespaces to display based on activeNamespaceCache (or all when no filter is active).
  Initializes an empty array for each of those namespaces and then assigns apps into the appropriate group.
  Falls back to a single workspace group when nothing is yet loaded, preserving prior behavior.
Namespaces are explicitly fetched on mount of the applications page to keep grouping logic in sync with the current filter state.

### Areas or cases that should be tested
Namespace with zero apps
  Create a new namespace without deploying any applications. 
  Open the applications page and confirm the new namespace appears with an empty table.
Applications page – no filter
  Navigate to the cluster applications page with multiple namespaces, some with apps and some without.
  Verify that every namespace appears with a titled applications table; namespaces with no apps show the empty state row instead of no table.

### Areas which could experience regressions
Namespace filtering logic: The applications page now depends more directly on activeNamespaceCache and namespace data;   incorrect cache state or missing namespace fetch could affect which groups are rendered.
Applications page performance: The additional findAll call for namespaces runs on mount; though lightweight, any issues in that request could affect initial load time or error handling

### Screenshot/Video
<img width="1605" height="830" alt="image" src="https://github.com/user-attachments/assets/c576e7fb-4f2b-492e-98fd-fac3cfd12ef7" />