### PR TITLE
chore: EPINIO-509 remove Show Configuration action from table rows

### DIFF
--- a/dashboard/pkg/epinio/utils/table-formatters.ts
+++ b/dashboard/pkg/epinio/utils/table-formatters.ts
@@ -108,15 +108,24 @@ export function makeActionMenu(row: any): HTMLElement {
   const el = document.createElement('trailhand-action-menu') as any;
 
   el.resource = row;
-  el.actions = (row.availableActions || []).map((action: any) => {
+  const actions = [] as any[];
+  (row.availableActions || []).forEach((action: any) => {
+    // do not add the showConfiguration action to the menu
+    if (action.action === 'showConfiguration') {
+      return;
+    }
+
     if (action.divider || typeof action.action !== 'string') {
-      return action;
+      actions.push(action);
+      return;
     }
 
     const actionName = action.action;
 
-    return { ...action, action: () => row[actionName]?.() };
+    actions.push({ ...action, action: () => row[actionName]?.() });
   });
+
+  el.actions = actions;
 
   return el;
 }


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->
EPINIO-509

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

Removes the "Show Configuration" option from action menus in tables. This option is redundant because the user can select "Edit Configuration" to view the info. 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Updated the makeActionMenu function to skip over the action if it is called "showConfiguration"

### Areas or cases that should be tested
<!-- Areas that should be tested . -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1440" height="478" alt="image" src="https://github.com/user-attachments/assets/184e93f2-41e1-4565-9b14-a50fd4c72b91" />
