### PR TITLE
feat: use trailhand modal in service delete

### DIFF
--- a/dashboard/pkg/epinio/components/service/ServiceDeleteModal.vue
+++ b/dashboard/pkg/epinio/components/service/ServiceDeleteModal.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useStore } from 'vuex';
+import EpinioServiceModel from 'models/services';
+import { EPINIO_TYPES } from '../../types';
+import { epinioExceptionToErrorsArray } from '../../utils/errors';
+import Banner from '@components/Banner/Banner.vue';
+
+const showDeleteModal = ref<boolean>(false);
+const serviceToDelete = ref<EpinioServiceModel | null>(null);
+const errors = ref<Array<string>>([]);
+const deletingService = ref<boolean>(false);
+
+const store = useStore();
+
+function openDelete(row: EpinioServiceModel) {
+  serviceToDelete.value = row;
+  showDeleteModal.value = true;
+}
+
+function closeDelete() {
+showDeleteModal.value = false;
+errors.value = [];
+}
+
+async function onSubmitDelete() {
+if (!serviceToDelete.value) {
+    return;
+}
+try {
+    deletingService.value = true;
+    await serviceToDelete.value.remove();
+    closeDelete();
+    store.dispatch('epinio/findAll', { type: EPINIO_TYPES.SERVICE_INSTANCE, opt: { force: true } });
+    store.dispatch('findAll', { type: 'applications', opt: { force: true } });
+} catch(e) {
+    errors.value = [];
+    errors.value = epinioExceptionToErrorsArray(e).map(JSON.stringify);
+} finally {
+    deletingService.value = false;
+}
+}
+defineExpose({
+  openDelete
+});
+</script> 
+
+<template>
+    <trailhand-modal
+        :open.prop="showDeleteModal"
+        title="Are you sure?"
+        @modal-close="closeDelete"
+    >
+        <div class="modal-content">
+        <p>You are attempting to delete the Instance <strong>{{ serviceToDelete?.meta.name }}</strong>.</p>
+        <div v-if="(serviceToDelete as any)?.boundapps?.length">
+            <p><strong>Caution: </strong>The following applications are bound to the Service Instance about to be deleted. Proceeding will unbind them prior to deletion.</p>
+            <ul>
+            <li v-for="app in (serviceToDelete as any)?.boundapps || []" :key="app">{{ app }}</li>
+            </ul>
+        </div>
+        <p v-else>No applications are bound to this Service Instance.</p>
+        <Banner
+            v-for="(err, i) in errors"
+            :key="i"
+            color="error"
+            :label="err"
+            />
+        </div>
+        <div slot="footer">
+        <trailhand-button @button-click="closeDelete" variant="secondary" class="mr-10"
+            >Cancel</trailhand-button
+        >
+        <trailhand-button @button-click="onSubmitDelete" :disabled="deletingService" variant="destructive"
+            >{{ deletingService ? 'Deleting...' : t('generic.delete') }}</trailhand-button
+        >
+        </div>
+    </trailhand-modal>
+</template>
+
+<style lang="scss" scoped>
+.modal-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 500px;
+}
+</style>

--- a/dashboard/pkg/epinio/detail/catalogservices.vue
+++ b/dashboard/pkg/epinio/detail/catalogservices.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, watchEffect } from 'vue';
 
 import EpinioCatalogServiceModel from '../models/catalogservices';
 import { EPINIO_TYPES } from '../types';
-import { makeStateTag, makeRouterLink, makeRouterLinksOrEmpty } from '../utils/table-formatters';
+import { makeStateTag, makeRouterLink, makeRouterLinksOrEmpty, overrideTableRows } from '../utils/table-formatters';
+import ServiceDeleteModal from '../components/service/ServiceDeleteModal.vue';
+import EpinioServiceModel from 'models/services';
+import { makeActionMenu } from '../utils/table-formatters';
 
 const store = useStore();
 const router = useRouter();
@@ -14,11 +17,61 @@ const t = store.getters['i18n/t'];
 const props = defineProps<{ value: EpinioCatalogServiceModel }>();
 
 const pending = ref<boolean>(true);
+const deleteModal = ref<InstanceType<typeof ServiceDeleteModal> | null>(null);
+const displayRows = ref<any[]>([]);
 
 onMounted(async () => {
   await store.dispatch(`epinio/findAll`, { type: EPINIO_TYPES.SERVICE_INSTANCE });
   pending.value = false;
 });
+
+watchEffect(() => {
+  const rows = props.value.services || [] as any[];
+
+  // Filter empty rows that are added during delete
+  const filtered = rows.filter((row: any) => row.id);
+
+  // Add custom service delete action to replace the built in rancher shell flow
+  const overrideProps = [{
+    prop: 'availableActions',
+    value: (row: EpinioServiceModel) => {
+      const newActions: any[] = [];
+      const availableActions = row.availableActions || [];
+      availableActions.forEach((action) => {
+        if (action.action === 'promptRemove') {
+          newActions.push({
+            action: 'removeService',
+            altAction: 'remove',
+            bulkAction: 'removeService',
+            bulkable: true,
+            enabled: row.canDelete,
+            icon: 'icon icon-trash',
+            label: 'Delete',
+            weight: -10
+          });
+        } else {
+          newActions.push(action);
+        }
+      });
+      return newActions;
+    },
+    conditionFn: (row: EpinioServiceModel) => {
+      return row.canDelete;
+    },
+  },
+  {
+    prop: 'removeService',
+    value: (row: EpinioServiceModel) => () => {
+      deleteModal.value?.openDelete(row);
+    },
+    conditionFn: (row: EpinioServiceModel) => {
+      return row.canDelete;
+    },
+  }];
+
+  const processedRows = overrideTableRows(filtered, overrideProps);
+  displayRows.value = processedRows;
+})
 
 const handleNavigate = (event: CustomEvent) => {
   router.push(event.detail.url);
@@ -68,12 +121,14 @@ const columns = [
       {{ t('epinio.catalogService.detail.servicesTitle', { catalogService: props.value.name }) }}
     </h2>
     <trailhand-table
-      :rows="props.value.services"
+      :ref="(el: any) => { if (el) el.renderActions = makeActionMenu; }"
+      :rows="displayRows"
       :columns="columns"
       :searchable="true"
       key-field="id"
       @navigate="handleNavigate"
     />
+    <ServiceDeleteModal ref="deleteModal" />
   </div>
 </template>
 

--- a/dashboard/pkg/epinio/list/namespaces.vue
+++ b/dashboard/pkg/epinio/list/namespaces.vue
@@ -10,6 +10,7 @@ import { validateKubernetesName } from '@shell/utils/validators/kubernetes-name'
 import { startPolling, stopPolling } from '../utils/polling';
 import { makeActionMenu } from '../utils/table-formatters';
 import EpinioNamespace from 'models/namespaces';
+import { overrideTableRows } from '../utils/table-formatters';
 
 defineProps<{
   schema: object,
@@ -42,34 +43,33 @@ watchEffect(() => {
   all.forEach((row) => { void row.meta; });
 
   // Add custom namespace delete action to replace the built in rancher shell flow
-  const overrides = all.map((row) => {
-  if (row.canDelete) {
-    Object.defineProperty(row, 'availableActions', {
-      value: [{
-        action: 'removeNamespace',
-        altAction: 'remove',
-        bulkAction: 'removeNamespace',
-        bulkable: true,
-        enabled: true,
-        icon: 'icon icon-trash',
-        label: 'Delete',
-        weight: -10
-      }],
-      writable: true,
-      configurable: true,
-    });
-    Object.defineProperty(row, 'removeNamespace', {
-      value: () => {
-        namespaceToDelete.value = row;
-        openDeleteModal();
-      },
-      writable: true,
-      configurable: true,
-    });
-  }
-  return row;
-});
-  displayRows.value = [...overrides];
+  const overrideProps = [{
+    prop: 'availableActions',
+    value: [{
+      action: 'removeNamespace',
+      altAction: 'remove',
+      bulkAction: 'removeNamespace',
+      bulkable: true,
+      enabled: true,
+      icon: 'icon icon-trash',
+      label: 'Delete',
+      weight: -10
+    }],
+    conditionFn: (row: EpinioNamespace) => {
+      return row.canDelete;
+    },
+  },
+  {
+    prop: 'removeNamespace',
+    value: (row: EpinioNamespace) => () => {
+      namespaceToDelete.value = row;
+      openDeleteModal();
+    },
+    conditionFn: (row: EpinioNamespace) => {
+      return row.canDelete;
+    },
+  }];
+  displayRows.value = overrideTableRows(all, overrideProps);
 });
 
 const validateCreate = computed(() => {

--- a/dashboard/pkg/epinio/list/services.vue
+++ b/dashboard/pkg/epinio/list/services.vue
@@ -191,7 +191,7 @@ const columns = [
     <div class="modal-content">
       <p>You are attempting to delete the Instance <strong>{{ serviceToDelete?.meta.name }}</strong>.</p>
       <div v-if="(serviceToDelete as any)?.boundapps?.length">
-        <p>The following applications are bound to the Service Instance about to be deleted. Please unbind them before proceeding.</p>
+        <p><strong>Caution: </strong>The following applications are bound to the Service Instance about to be deleted. Proceeding will unbind them prior to deletion.</p>
         <ul>
           <li v-for="app in (serviceToDelete as any)?.boundapps || []" :key="app">{{ app }}</li>
         </ul>
@@ -208,7 +208,7 @@ const columns = [
       <trailhand-button @button-click="closeDeleteModal" variant="secondary" class="mr-10"
         >Cancel</trailhand-button
       >
-      <trailhand-button @button-click="onSubmitDelete" :disabled="deletingService || (serviceToDelete as any)?.boundapps?.length" variant="destructive"
+      <trailhand-button @button-click="onSubmitDelete" :disabled="deletingService" variant="destructive"
         >{{ deletingService ? 'Deleting...' : t('generic.delete') }}</trailhand-button
       >
     </div>

--- a/dashboard/pkg/epinio/list/services.vue
+++ b/dashboard/pkg/epinio/list/services.vue
@@ -6,12 +6,11 @@ import { useRouter } from 'vue-router';
 import { EPINIO_TYPES } from '../types';
 import { startPolling, stopPolling } from '../utils/polling';
 import Masthead from '@shell/components/ResourceList/Masthead';
-import Banner from '@components/Banner/Banner.vue';
 import { createEpinioRoute } from '../utils/custom-routing';
 import { makeStateTag, makeRouterLink, makeRouterLinksOrEmpty, makeActionMenu } from '../utils/table-formatters';
 import EpinioServiceModel from 'models/services';
 import { overrideTableRows } from '../utils/table-formatters';
-import { epinioExceptionToErrorsArray } from '../utils/errors';
+import ServiceDeleteModal from '../components/service/ServiceDeleteModal.vue';
 
 defineProps<{
   schema: object,
@@ -22,10 +21,7 @@ const resource: string = EPINIO_TYPES.SERVICE_INSTANCE;
 const store = useStore();
 const router = useRouter();
 
-const showDeleteModal = ref<boolean>(false);
-const serviceToDelete = ref<EpinioServiceModel | null>(null);
-const errors = ref<Array<string>>([]);
-const deletingService = ref<boolean>(false);
+const deleteModal = ref<InstanceType<typeof ServiceDeleteModal> | null>(null);
 
 onMounted(() => {
   store.dispatch(`epinio/findAll`, { type: EPINIO_TYPES.SERVICE_INSTANCE });
@@ -79,8 +75,7 @@ const rows = computed(() => {
   {
     prop: 'removeService',
     value: (row: EpinioServiceModel) => () => {
-      serviceToDelete.value = row;
-      openDeleteModal();
+      deleteModal.value?.openDelete(row);
     },
     conditionFn: (row: EpinioServiceModel) => {
       return row.canDelete;
@@ -95,32 +90,6 @@ const handleNavigate = (event: CustomEvent) => {
   router.push(event.detail.url);
 };
 
-function openDeleteModal() {
-  showDeleteModal.value = true;
-}
-
-function closeDeleteModal() {
-  showDeleteModal.value = false;
-  errors.value = [];
-}
-
-async function onSubmitDelete() {
-  if (!serviceToDelete.value) {
-    return;
-  }
-  try {
-    deletingService.value = true;
-    await serviceToDelete.value.remove();
-    closeDeleteModal();
-    store.dispatch('epinio/findAll', { type: EPINIO_TYPES.SERVICE_INSTANCE, opt: { force: true } });
-    store.dispatch('findAll', { type: 'applications', opt: { force: true } });
-  } catch(e) {
-    errors.value = [];
-    errors.value = epinioExceptionToErrorsArray(e).map(JSON.stringify);
-  } finally {
-    deletingService.value = false;
-  }
-}
 
 const columns = [
   {
@@ -183,36 +152,7 @@ const columns = [
     key-field="id"
     @navigate="handleNavigate"
   />
-  <trailhand-modal
-    :open.prop="showDeleteModal"
-    title="Are you sure?"
-    @modal-close="closeDeleteModal"
-  >
-    <div class="modal-content">
-      <p>You are attempting to delete the Instance <strong>{{ serviceToDelete?.meta.name }}</strong>.</p>
-      <div v-if="(serviceToDelete as any)?.boundapps?.length">
-        <p><strong>Caution: </strong>The following applications are bound to the Service Instance about to be deleted. Proceeding will unbind them prior to deletion.</p>
-        <ul>
-          <li v-for="app in (serviceToDelete as any)?.boundapps || []" :key="app">{{ app }}</li>
-        </ul>
-      </div>
-      <p v-else>No applications are bound to this Service Instance.</p>
-      <Banner
-          v-for="(err, i) in errors"
-          :key="i"
-          color="error"
-          :label="err"
-        />
-    </div>
-    <div slot="footer">
-      <trailhand-button @button-click="closeDeleteModal" variant="secondary" class="mr-10"
-        >Cancel</trailhand-button
-      >
-      <trailhand-button @button-click="onSubmitDelete" :disabled="deletingService" variant="destructive"
-        >{{ deletingService ? 'Deleting...' : t('generic.delete') }}</trailhand-button
-      >
-    </div>
-  </trailhand-modal>
+  <ServiceDeleteModal ref="deleteModal" />
 </template>
 
 <style lang="scss" scoped>

--- a/dashboard/pkg/epinio/list/services.vue
+++ b/dashboard/pkg/epinio/list/services.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted } from 'vue';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 
 import { EPINIO_TYPES } from '../types';
 import { startPolling, stopPolling } from '../utils/polling';
 import Masthead from '@shell/components/ResourceList/Masthead';
+import Banner from '@components/Banner/Banner.vue';
 import { createEpinioRoute } from '../utils/custom-routing';
 import { makeStateTag, makeRouterLink, makeRouterLinksOrEmpty, makeActionMenu } from '../utils/table-formatters';
+import EpinioServiceModel from 'models/services';
+import { overrideTableRows } from '../utils/table-formatters';
+import { epinioExceptionToErrorsArray } from '../utils/errors';
 
 defineProps<{
   schema: object,
@@ -17,6 +21,11 @@ const resource: string = EPINIO_TYPES.SERVICE_INSTANCE;
 
 const store = useStore();
 const router = useRouter();
+
+const showDeleteModal = ref<boolean>(false);
+const serviceToDelete = ref<EpinioServiceModel | null>(null);
+const errors = ref<Array<string>>([]);
+const deletingService = ref<boolean>(false);
 
 onMounted(() => {
   store.dispatch(`epinio/findAll`, { type: EPINIO_TYPES.SERVICE_INSTANCE });
@@ -36,12 +45,82 @@ const rows = computed(() => {
 
   all.forEach((row: any) => { void row.status; void row.stateDisplay; void row.meta; });
 
-  return [...all];
+  // Filter empty rows that are added during delete
+  const filtered = all.filter((row) => row.id);
+
+  // Add custom service delete action to replace the built in rancher shell flow
+  const overrideProps = [{
+    prop: 'availableActions',
+    value: (row: EpinioServiceModel) => {
+      const newActions: any[] = [];
+      const availableActions = row.availableActions || [];
+      availableActions.forEach((action) => {
+        if (action.action === 'promptRemove') {
+          newActions.push({
+            action: 'removeService',
+            altAction: 'remove',
+            bulkAction: 'removeService',
+            bulkable: true,
+            enabled: row.canDelete,
+            icon: 'icon icon-trash',
+            label: 'Delete',
+            weight: -10
+          });
+        } else {
+          newActions.push(action);
+        }
+      });
+      return newActions;
+    },
+    conditionFn: (row: EpinioServiceModel) => {
+      return row.canDelete;
+    },
+  },
+  {
+    prop: 'removeService',
+    value: (row: EpinioServiceModel) => () => {
+      serviceToDelete.value = row;
+      openDeleteModal();
+    },
+    conditionFn: (row: EpinioServiceModel) => {
+      return row.canDelete;
+    },
+  }];
+
+  const processedRows = overrideTableRows(filtered, overrideProps);
+  return processedRows;
 });
 
 const handleNavigate = (event: CustomEvent) => {
   router.push(event.detail.url);
 };
+
+function openDeleteModal() {
+  showDeleteModal.value = true;
+}
+
+function closeDeleteModal() {
+  showDeleteModal.value = false;
+  errors.value = [];
+}
+
+async function onSubmitDelete() {
+  if (!serviceToDelete.value) {
+    return;
+  }
+  try {
+    deletingService.value = true;
+    await serviceToDelete.value.remove();
+    closeDeleteModal();
+    store.dispatch('epinio/findAll', { type: EPINIO_TYPES.SERVICE_INSTANCE, opt: { force: true } });
+    store.dispatch('findAll', { type: 'applications', opt: { force: true } });
+  } catch(e) {
+    errors.value = [];
+    errors.value = epinioExceptionToErrorsArray(e).map(JSON.stringify);
+  } finally {
+    deletingService.value = false;
+  }
+}
 
 const columns = [
   {
@@ -104,6 +183,36 @@ const columns = [
     key-field="id"
     @navigate="handleNavigate"
   />
+  <trailhand-modal
+    :open.prop="showDeleteModal"
+    title="Are you sure?"
+    @modal-close="closeDeleteModal"
+  >
+    <div class="modal-content">
+      <p>You are attempting to delete the Instance <strong>{{ serviceToDelete?.meta.name }}</strong>.</p>
+      <div v-if="(serviceToDelete as any)?.boundapps?.length">
+        <p>The following applications are bound to the Service Instance about to be deleted. Please unbind them before proceeding.</p>
+        <ul>
+          <li v-for="app in (serviceToDelete as any)?.boundapps || []" :key="app">{{ app }}</li>
+        </ul>
+      </div>
+      <p v-else>No applications are bound to this Service Instance.</p>
+      <Banner
+          v-for="(err, i) in errors"
+          :key="i"
+          color="error"
+          :label="err"
+        />
+    </div>
+    <div slot="footer">
+      <trailhand-button @button-click="closeDeleteModal" variant="secondary" class="mr-10"
+        >Cancel</trailhand-button
+      >
+      <trailhand-button @button-click="onSubmitDelete" :disabled="deletingService || (serviceToDelete as any)?.boundapps?.length" variant="destructive"
+        >{{ deletingService ? 'Deleting...' : t('generic.delete') }}</trailhand-button
+      >
+    </div>
+  </trailhand-modal>
 </template>
 
 <style lang="scss" scoped>
@@ -111,5 +220,11 @@ trailhand-table {
   --sortable-table-row-hover-bg: var(--sortable-table-hover-bg);
   --sortable-table-header-hover-bg: var(--sortable-table-hover-bg);
   --sortable-table-header-sorted-bg: var(--sortable-table-hover-bg);
+}
+.modal-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 500px;
 }
 </style>

--- a/dashboard/pkg/epinio/models/services.js
+++ b/dashboard/pkg/epinio/models/services.js
@@ -9,7 +9,7 @@ export default class EpinioServiceModel extends EpinioNamespacedResource {
       self:   this.getUrl(),
       remove: this.getUrl(),
       bind:   `${ this.getUrl() }/bind`,
-      unmounted: `${ this.getUrl() }/unmounted`,
+      unbind: `${ this.getUrl() }/unbind`,
       create: this.getUrl(this.metadata?.namespace, null) // ensure name is null
     };
   }
@@ -102,7 +102,7 @@ export default class EpinioServiceModel extends EpinioNamespacedResource {
   }
 
   async unbindApp(appName) {
-    await this.followLink('unmounted', {
+    await this.followLink('unbind', {
       method:  'post',
       headers: {
         'content-type': 'application/json',
@@ -117,6 +117,9 @@ export default class EpinioServiceModel extends EpinioNamespacedResource {
   }
 
   async remove() {
+    if (this.boundapps?.length) {
+      await Promise.all(this.boundapps.map((appName) => this.unbindApp(appName)));
+    }
     await this.delete(true);
   }
 

--- a/dashboard/pkg/epinio/utils/table-formatters.ts
+++ b/dashboard/pkg/epinio/utils/table-formatters.ts
@@ -364,7 +364,6 @@ export function makeProgressStateCell(row: any): HTMLElement {
  * Overrides a property on a table row object with a new value, making it writable and configurable.
  */
 export function overrideTableRowProp(row: any, prop: string, value: any): any {
-  console.log(`Overriding row property: ${ prop } with value:`, value);
   Object.defineProperty(row, prop, {
       value: value,
       writable: true,

--- a/dashboard/pkg/epinio/utils/table-formatters.ts
+++ b/dashboard/pkg/epinio/utils/table-formatters.ts
@@ -359,3 +359,41 @@ export function makeProgressStateCell(row: any): HTMLElement {
 
   return tag;
 }
+
+/**
+ * Overrides a property on a table row object with a new value, making it writable and configurable.
+ */
+export function overrideTableRowProp(row: any, prop: string, value: any): any {
+  console.log(`Overriding row property: ${ prop } with value:`, value);
+  Object.defineProperty(row, prop, {
+      value: value,
+      writable: true,
+      configurable: true,
+    });
+
+  return row;
+};
+
+type RowOverride = {
+  prop: string;
+  value: any | ((row: any) => any);
+  conditionFn?: (row: any) => boolean;
+}
+
+/**
+ * Applies multiple property overrides to each row in a table, based on optional conditions.
+ * Each override specifies the property to override, the new value (or a function to compute it),
+ * and an optional condition function that determines whether to apply the override for a given row.
+ * Returns a new array of rows with the overrides applied.
+ */
+export function overrideTableRows<T extends object>(rows: T[], overrides: RowOverride[]): T[] {
+  return rows.map((row) => {
+    overrides.forEach((override) => {
+      if (!override.conditionFn || override.conditionFn(row)) {
+        const value = typeof override.value === 'function' ? override.value(row) : override.value;
+        overrideTableRowProp(row, override.prop, value);
+      }
+    });
+    return row;
+  });
+}


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] Code is well documented
- [x] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->
 
Service Instance Deletion

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
-  Implement trailhand modal for service deletion. 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- Refactored some of the logic adding during namespace deletion to be a reusable util. This util accepts the rows, and some config objects for properties to add or override, and then will return the updated rows
- This is because in order to use the trailhand modal and not the default rancher flow we need to override the promptRemove action on the row

### Areas or cases that should be tested
<!-- Areas that should be tested . -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1707" height="1294" alt="image" src="https://github.com/user-attachments/assets/ed74bbf1-3cbf-4311-ae38-12ba52deb978" />

