### PR TITLE
Chore/server pagination

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -41,6 +41,5 @@
     "@vue/eslint-config-standard": "5.1.2",
     "@vue/eslint-config-typescript": "^11.0.3",
     "globals": "^16.2.0"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -5,7 +5,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@krumio/trailhand-ui": "^1.9.14",
+    "@krumio/trailhand-ui": "^1.9.17",
     "@rancher/shell": "3.0.7",
     "@types/lodash": "^4.17.16",
     "eslint": "^9.28.0",
@@ -41,5 +41,6 @@
     "@vue/eslint-config-standard": "5.1.2",
     "@vue/eslint-config-typescript": "^11.0.3",
     "globals": "^16.2.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -41,5 +41,6 @@
     "@vue/eslint-config-standard": "5.1.2",
     "@vue/eslint-config-typescript": "^11.0.3",
     "globals": "^16.2.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/dashboard/pkg/epinio/list/appcharts.vue
+++ b/dashboard/pkg/epinio/list/appcharts.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { EPINIO_TYPES } from '../types';
 import { useStore } from 'vuex';
-import { ref, onMounted, onUnmounted, watchEffect } from 'vue';
+import { computed, ref, onMounted, onUnmounted, watchEffect } from 'vue';
 import { startPolling, stopPolling } from '../utils/polling';
 
 defineProps<{ schema: object }>(); // Keep for compatibility
@@ -9,18 +9,24 @@ defineProps<{ schema: object }>(); // Keep for compatibility
 const store = useStore();
 
 const pending = ref(true);
-const paginating = ref(false);
 const rows = ref<any[]>([]);
 
-const handlePageChange = async(e: CustomEvent) => {
-  if (paginating.value) return;
+const paginationMeta = computed(() => store.getters['epinio/paginationMeta'](EPINIO_TYPES.APP_CHARTS));
+const currentPage = computed(() => store.getters['epinio/currentPaginationPage'](EPINIO_TYPES.APP_CHARTS));
+
+const paginating = ref(false);
+
+async function goToPage(page: number) {
+  const meta = paginationMeta.value;
+
+  if (meta && (page < 1 || page > meta.totalPages)) return;
   paginating.value = true;
   try {
-    await store.dispatch('epinio/goToPage', { type: EPINIO_TYPES.APP_CHARTS, page: e.detail.page });
+    await store.dispatch('epinio/goToPage', { type: EPINIO_TYPES.APP_CHARTS, page });
   } finally {
     paginating.value = false;
   }
-};
+}
 
 watchEffect(() => {
   const all = store.getters['epinio/all'](EPINIO_TYPES.APP_CHARTS) as any[];
@@ -66,12 +72,12 @@ const columns = [
     :rows="rows"
     :columns="columns"
     :searchable="true"
+    :server-side="!!paginationMeta"
+    :total-items="paginationMeta?.totalItems ?? rows.length"
+    :current-page="currentPage"
     :loading="pending || paginating"
-    :total-items="store.getters['epinio/paginationMeta'](EPINIO_TYPES.APP_CHARTS)?.totalItems ?? store.getters['epinio/all'](EPINIO_TYPES.APP_CHARTS).length"
-    :server-side="!!store.getters['epinio/paginationMeta'](EPINIO_TYPES.APP_CHARTS)"
-    rows-per-page="10"
     key-field="id"
-    @page-change="handlePageChange"
+    @page-change="(e: CustomEvent) => goToPage(e.detail.page)"
   />
 </template>
 
@@ -81,4 +87,5 @@ trailhand-table {
   --sortable-table-header-hover-bg: var(--sortable-table-hover-bg);
   --sortable-table-header-sorted-bg: var(--sortable-table-hover-bg);
 }
+
 </style>

--- a/dashboard/pkg/epinio/list/appcharts.vue
+++ b/dashboard/pkg/epinio/list/appcharts.vue
@@ -9,7 +9,18 @@ defineProps<{ schema: object }>(); // Keep for compatibility
 const store = useStore();
 
 const pending = ref(true);
+const paginating = ref(false);
 const rows = ref<any[]>([]);
+
+const handlePageChange = async(e: CustomEvent) => {
+  if (paginating.value) return;
+  paginating.value = true;
+  try {
+    await store.dispatch('epinio/goToPage', { type: EPINIO_TYPES.APP_CHARTS, page: e.detail.page });
+  } finally {
+    paginating.value = false;
+  }
+};
 
 watchEffect(() => {
   const all = store.getters['epinio/all'](EPINIO_TYPES.APP_CHARTS) as any[];
@@ -55,8 +66,12 @@ const columns = [
     :rows="rows"
     :columns="columns"
     :searchable="true"
-    :loading="pending"
+    :loading="pending || paginating"
+    :total-items="store.getters['epinio/paginationMeta'](EPINIO_TYPES.APP_CHARTS)?.totalItems ?? store.getters['epinio/all'](EPINIO_TYPES.APP_CHARTS).length"
+    :server-side="!!store.getters['epinio/paginationMeta'](EPINIO_TYPES.APP_CHARTS)"
+    rows-per-page="10"
     key-field="id"
+    @page-change="handlePageChange"
   />
 </template>
 

--- a/dashboard/pkg/epinio/list/configurations.vue
+++ b/dashboard/pkg/epinio/list/configurations.vue
@@ -15,6 +15,7 @@ const router = useRouter();
 defineProps<{ schema: object }>(); // Keep for compatibility
 
 const resource: string = EPINIO_TYPES.CONFIGURATION;
+const paginating = ref(false);
 const configModal = ref<InstanceType<typeof ConfigurationModal> | null>(null);
 const deleteModal = ref<InstanceType<typeof ConfigurationDeleteModal> | null>(null);
 const windowWidth = ref(window.innerWidth);
@@ -86,6 +87,16 @@ watchEffect(() => {
 
 const handleNavigate = (event: CustomEvent) => {
   router.push(event.detail.url);
+};
+
+const handlePageChange = async(e: CustomEvent) => {
+  if (paginating.value) return;
+  paginating.value = true;
+  try {
+    await store.dispatch('epinio/goToPage', { type: resource, page: e.detail.page });
+  } finally {
+    paginating.value = false;
+  }
 };
 
 const allColumns = [
@@ -182,8 +193,13 @@ const columns = computed(() => {
       :rows="displayRows"
       :columns="columns"
       :searchable="true"
+      :total-items="store.getters['epinio/paginationMeta'](resource)?.totalItems ?? store.getters['epinio/all'](resource).length"
+      :loading="paginating"
+      :server-side="!!store.getters['epinio/paginationMeta'](resource)"
+      rows-per-page="10"
       key-field="id"
       @navigate="handleNavigate"
+      @page-change="handlePageChange"
     />
     <ConfigurationModal ref="configModal" />
     <ConfigurationDeleteModal ref="deleteModal" />

--- a/dashboard/pkg/epinio/list/configurations.vue
+++ b/dashboard/pkg/epinio/list/configurations.vue
@@ -15,7 +15,7 @@ const router = useRouter();
 defineProps<{ schema: object }>(); // Keep for compatibility
 
 const resource: string = EPINIO_TYPES.CONFIGURATION;
-const paginating = ref(false);
+
 const configModal = ref<InstanceType<typeof ConfigurationModal> | null>(null);
 const deleteModal = ref<InstanceType<typeof ConfigurationDeleteModal> | null>(null);
 const windowWidth = ref(window.innerWidth);
@@ -89,15 +89,22 @@ const handleNavigate = (event: CustomEvent) => {
   router.push(event.detail.url);
 };
 
-const handlePageChange = async(e: CustomEvent) => {
-  if (paginating.value) return;
+const paginationMeta = computed(() => store.getters['epinio/paginationMeta'](resource));
+const currentPage = computed(() => store.getters['epinio/currentPaginationPage'](resource));
+
+const paginating = ref(false);
+
+async function goToPage(page: number) {
+  const meta = paginationMeta.value;
+
+  if (meta && (page < 1 || page > meta.totalPages)) return;
   paginating.value = true;
   try {
-    await store.dispatch('epinio/goToPage', { type: resource, page: e.detail.page });
+    await store.dispatch('epinio/goToPage', { type: resource, page });
   } finally {
     paginating.value = false;
   }
-};
+}
 
 const allColumns = [
   {
@@ -193,13 +200,13 @@ const columns = computed(() => {
       :rows="displayRows"
       :columns="columns"
       :searchable="true"
-      :total-items="store.getters['epinio/paginationMeta'](resource)?.totalItems ?? store.getters['epinio/all'](resource).length"
+      :server-side="!!paginationMeta"
+      :total-items="paginationMeta?.totalItems ?? displayRows.length"
+      :current-page="currentPage"
       :loading="paginating"
-      :server-side="!!store.getters['epinio/paginationMeta'](resource)"
-      rows-per-page="10"
       key-field="id"
       @navigate="handleNavigate"
-      @page-change="handlePageChange"
+      @page-change="(e: CustomEvent) => goToPage(e.detail.page)"
     />
     <ConfigurationModal ref="configModal" />
     <ConfigurationDeleteModal ref="deleteModal" />
@@ -213,4 +220,5 @@ trailhand-table {
   --sortable-table-header-sorted-bg: var(--sortable-table-hover-bg);
   overflow-wrap: anywhere;
 }
+
 </style>

--- a/dashboard/pkg/epinio/list/namespaces.vue
+++ b/dashboard/pkg/epinio/list/namespaces.vue
@@ -22,8 +22,18 @@ const t = store.getters['i18n/t'];
 
 const errors = ref<Array<string>>([]);
 const resource: string = EPINIO_TYPES.NAMESPACE;
-
+const paginating = ref(false);
 const displayRows = ref<EpinioNamespace[]>([]);
+
+const handlePageChange = async(e: CustomEvent) => {
+  if (paginating.value) return;
+  paginating.value = true;
+  try {
+    await store.dispatch('epinio/goToPage', { type: resource, page: e.detail.page });
+  } finally {
+    paginating.value = false;
+  }
+};
 
 const value = ref<EpinioNamespace>({ meta: { name: '' } } as EpinioNamespace);
 const showCreateModal = ref<boolean>(false);
@@ -220,7 +230,12 @@ const columns = [
       :ref="(el: any) => { if (el) el.renderActions = makeActionMenu; }"
       :rows="displayRows"
       :columns="columns"
+      :total-items="store.getters['epinio/paginationMeta'](resource)?.totalItems ?? store.getters['epinio/all'](resource).length"
+      :loading="paginating"
+      :server-side="!!store.getters['epinio/paginationMeta'](resource)"
+      rows-per-page="10"
       key-field="_key"
+      @page-change="handlePageChange"
     />
     <trailhand-modal
       :open.prop="showCreateModal"

--- a/dashboard/pkg/epinio/list/namespaces.vue
+++ b/dashboard/pkg/epinio/list/namespaces.vue
@@ -22,18 +22,24 @@ const t = store.getters['i18n/t'];
 
 const errors = ref<Array<string>>([]);
 const resource: string = EPINIO_TYPES.NAMESPACE;
-const paginating = ref(false);
 const displayRows = ref<EpinioNamespace[]>([]);
 
-const handlePageChange = async(e: CustomEvent) => {
-  if (paginating.value) return;
+const paginationMeta = computed(() => store.getters['epinio/paginationMeta'](resource));
+const currentPage = computed(() => store.getters['epinio/currentPaginationPage'](resource));
+
+const paginating = ref(false);
+
+async function goToPage(page: number) {
+  const meta = paginationMeta.value;
+
+  if (meta && (page < 1 || page > meta.totalPages)) return;
   paginating.value = true;
   try {
-    await store.dispatch('epinio/goToPage', { type: resource, page: e.detail.page });
+    await store.dispatch('epinio/goToPage', { type: resource, page });
   } finally {
     paginating.value = false;
   }
-};
+}
 
 const value = ref<EpinioNamespace>({ meta: { name: '' } } as EpinioNamespace);
 const showCreateModal = ref<boolean>(false);
@@ -230,12 +236,12 @@ const columns = [
       :ref="(el: any) => { if (el) el.renderActions = makeActionMenu; }"
       :rows="displayRows"
       :columns="columns"
-      :total-items="store.getters['epinio/paginationMeta'](resource)?.totalItems ?? store.getters['epinio/all'](resource).length"
+      :server-side="!!paginationMeta"
+      :total-items="paginationMeta?.totalItems ?? displayRows.length"
+      :current-page="currentPage"
       :loading="paginating"
-      :server-side="!!store.getters['epinio/paginationMeta'](resource)"
-      rows-per-page="10"
       key-field="_key"
-      @page-change="handlePageChange"
+      @page-change="(e: CustomEvent) => goToPage(e.detail.page)"
     />
     <trailhand-modal
       :open.prop="showCreateModal"
@@ -324,9 +330,9 @@ const columns = [
 }
 
 .modal-content {
-  display: flex; 
-  flex-direction: column; 
-  gap: 1rem; 
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   width: 500px;
 }
 
@@ -335,5 +341,6 @@ trailhand-table {
   --sortable-table-header-hover-bg: var(--sortable-table-hover-bg);
   --sortable-table-header-sorted-bg: var(--sortable-table-hover-bg);
 }
+
 </style>
 

--- a/dashboard/pkg/epinio/list/services.vue
+++ b/dashboard/pkg/epinio/list/services.vue
@@ -21,6 +21,18 @@ const t = store.getters['i18n/t'];
 const router = useRouter();
 
 const resource: string = EPINIO_TYPES.SERVICE_INSTANCE;
+const paginating = ref(false);
+
+const handlePageChange = async(e: CustomEvent) => {
+  if (paginating.value) return;
+  paginating.value = true;
+  try {
+    await store.dispatch('epinio/goToPage', { type: resource, page: e.detail.page });
+  } finally {
+    paginating.value = false;
+  }
+};
+
 const serviceModal = ref<InstanceType<typeof ServiceInstanceModal> | null>(null);
 const deleteModal = ref<InstanceType<typeof ServiceDeleteModal> | null>(null);
 const displayRows = ref<any[]>([]);
@@ -114,7 +126,6 @@ const handleNavigate = (event: CustomEvent) => {
   router.push(event.detail.url);
 };
 
-
 const columns = [
   {
     field: 'stateDisplay',
@@ -184,8 +195,13 @@ const columns = [
       :rows="displayRows"
       :columns="columns"
       :searchable="true"
+      :total-items="store.getters['epinio/paginationMeta'](resource)?.totalItems ?? store.getters['epinio/all'](resource).length"
+      :loading="paginating"
+      :server-side="!!store.getters['epinio/paginationMeta'](resource)"
+      rows-per-page="10"
       key-field="id"
       @navigate="handleNavigate"
+      @page-change="handlePageChange"
     />
     <ServiceInstanceModal ref="serviceModal" />
     <ServiceDeleteModal ref="deleteModal" />

--- a/dashboard/pkg/epinio/list/services.vue
+++ b/dashboard/pkg/epinio/list/services.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watchEffect } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watchEffect } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 
@@ -21,17 +21,22 @@ const t = store.getters['i18n/t'];
 const router = useRouter();
 
 const resource: string = EPINIO_TYPES.SERVICE_INSTANCE;
+const paginationMeta = computed(() => store.getters['epinio/paginationMeta'](resource));
+const currentPage = computed(() => store.getters['epinio/currentPaginationPage'](resource));
+
 const paginating = ref(false);
 
-const handlePageChange = async(e: CustomEvent) => {
-  if (paginating.value) return;
+async function goToPage(page: number) {
+  const meta = paginationMeta.value;
+
+  if (meta && (page < 1 || page > meta.totalPages)) return;
   paginating.value = true;
   try {
-    await store.dispatch('epinio/goToPage', { type: resource, page: e.detail.page });
+    await store.dispatch('epinio/goToPage', { type: resource, page });
   } finally {
     paginating.value = false;
   }
-};
+}
 
 const serviceModal = ref<InstanceType<typeof ServiceInstanceModal> | null>(null);
 const deleteModal = ref<InstanceType<typeof ServiceDeleteModal> | null>(null);
@@ -195,13 +200,13 @@ const columns = [
       :rows="displayRows"
       :columns="columns"
       :searchable="true"
-      :total-items="store.getters['epinio/paginationMeta'](resource)?.totalItems ?? store.getters['epinio/all'](resource).length"
+      :server-side="!!paginationMeta"
+      :total-items="paginationMeta?.totalItems ?? displayRows.length"
+      :current-page="currentPage"
       :loading="paginating"
-      :server-side="!!store.getters['epinio/paginationMeta'](resource)"
-      rows-per-page="10"
       key-field="id"
       @navigate="handleNavigate"
-      @page-change="handlePageChange"
+      @page-change="(e: CustomEvent) => goToPage(e.detail.page)"
     />
     <ServiceInstanceModal ref="serviceModal" />
     <ServiceDeleteModal ref="deleteModal" />
@@ -214,10 +219,12 @@ trailhand-table {
   --sortable-table-header-hover-bg: var(--sortable-table-hover-bg);
   --sortable-table-header-sorted-bg: var(--sortable-table-hover-bg);
 }
+
 .modal-content {
   display: flex;
   flex-direction: column;
   gap: 1rem;
   max-width: 500px;
 }
+
 </style>

--- a/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
@@ -8,9 +8,7 @@ import Masthead from '@shell/components/ResourceList/Masthead';
 
 import { EPINIO_TYPES } from '../../../../types';
 import { createEpinioRoute } from '../../../../utils/custom-routing';
-
 import { startPolling, stopPolling } from '../../../../utils/polling';
-
 import {
   makeActionMenu,
   makeStateTag,
@@ -29,57 +27,108 @@ const schema = ref(store.getters['epinio/schemaFor'](resource));
 const createLocation = computed(() =>
   createEpinioRoute('c-cluster-applications-createapp', { cluster: store.getters['clusterId'] })
 );
+const openCreateRoute = () => router.push(createLocation.value);
 
-const openCreateRoute = () => {
-  router.push(createLocation.value);
-};
+const pending = ref(true);
 
-const rows = computed(() => store.getters['epinio/all'](resource));
+// Global state
+// Touch stateDisplay and meta to ensure reactivity with _MERGE polling that replaces all properties.
+const rows = computed(() => {
+  const all = store.getters['epinio/all'](EPINIO_TYPES.APP) as any[];
 
-const windowWidth = ref(window.innerWidth);
-const onResize = () => { windowWidth.value = window.innerWidth; };
+  all.forEach((row: any) => { void row.stateDisplay; void row.meta; });
 
-// Group applications by namespace
+  return [...all];
+});
+
+// Groups all apps by namespace, respecting the active namespace filter.
 const groupedByNamespace = computed(() => {
-  // Access the cache key to trigger namespace filter changes
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const cacheKey = store.state.activeNamespaceCacheKey;
+  const _cacheKey = store.state.activeNamespaceCacheKey;
   const activeNamespaces = store.state.activeNamespaceCache;
-
   const groups: Record<string, any[]> = {};
 
   rows.value.forEach((app: any) => {
     const namespace = app.meta?.namespace || 'default';
-
     if (!activeNamespaces || Object.keys(activeNamespaces).length === 0 || activeNamespaces[namespace]) {
-      if (!groups[namespace]) {
-        groups[namespace] = [];
-      }
+      if (!groups[namespace]) groups[namespace] = [];
       groups[namespace].push(app);
     }
   });
 
-  if (Object.keys(groups).length === 0) {
-    groups['workspace'] = [];
-  }
-
   return groups;
 });
 
-const pending = ref(true);
-const paginating = ref<Record<string, boolean>>({});
+// Sorted list of namespaces that have at least one app.
+const namespacesWithApps = computed(() =>
+  Object.keys(groupedByNamespace.value)
+    .filter(ns => groupedByNamespace.value[ns].length > 0)
+    .sort()
+);
 
-const handlePageChange = async(e: CustomEvent, namespace: string) => {
-  if (paginating.value[namespace]) return;
-  paginating.value = { ...paginating.value, [namespace]: true };
-  try {
-    await store.dispatch('epinio/goToPage', { type: resource, page: e.detail.page });
-  } finally {
-    paginating.value = { ...paginating.value, [namespace]: false };
-  }
-};
+// Responsive columns
+// Touch windowWidth to trigger recomputation on resize
 
-// Per-namespace search queries (keyed by namespace name)
+const windowWidth = ref(window.innerWidth);
+const onResize = () => { windowWidth.value = window.innerWidth; };
+
+const allColumns = [
+  {
+    field:     'stateDisplay',
+    label:     'State',
+    width:     '125px',
+    formatter: (_value: string, row: any) => makeStateTag(row)
+  },
+  {
+    field: 'nameDisplay',
+    label: 'Name',
+    width: '180px',
+    link:  (row: any) => {
+      try { return router.resolve(row.detailLocation).href; } catch { return '#'; }
+    }
+  },
+  { field: 'deployment.status', label: 'Status', width: '75px' },
+  {
+    field:     'route',
+    label:     'Routes',
+    width:     '180px',
+    sortable:  false,
+    formatter: (_value: any, row: any) => makeAppRoutesCell(row)
+  },
+  {
+    field:     'boundConfigs',
+    label:     'Bound Configs',
+    width:     '180px',
+    sortable:  false,
+    formatter: (_value: any, row: any) => makeRouterLinksOrEmpty(row.allConfigurations, router)
+  },
+  {
+    field:     'boundServices',
+    label:     'Bound Services',
+    width:     '180px',
+    sortable:  false,
+    formatter: (_value: any, row: any) => makeBoundServicesCell(row, router)
+  },
+  { field: 'deployment.username', label: 'Last Deployed By', width: '150px' },
+  { field: 'meta.createdAt',      label: 'Age',              width: '50px', formatter: 'age' }
+];
+
+const columns = computed(() => {
+  const w = windowWidth.value;
+  const hide = new Set<string>();
+
+  if (w < 1700) hide.add('deployment.username');
+  if (w < 1500) hide.add('deployment.status');
+  if (w < 1275) { hide.add('boundConfigs'); hide.add('boundServices'); }
+  if (w < 1100) hide.add('meta.createdAt');
+  if (w < 875)  hide.add('route');
+
+  return allColumns.filter(col => !hide.has(col.field));
+});
+
+// Per-namespace search
+// Stores the search query for each namespace group. Keys are namespace names, values are the current search query for that namespace.
+
 const searchQueries = ref<Record<string, string>>({});
 
 function getNestedValue(obj: any, path: string): any {
@@ -89,9 +138,7 @@ function getNestedValue(obj: any, path: string): any {
 function getFilteredApps(apps: any[], namespace: string): any[] {
   const query = (searchQueries.value[namespace] || '').toLowerCase().trim();
 
-  if (!query) {
-    return apps;
-  }
+  if (!query) return apps;
 
   return apps.filter(app =>
     columns.value.some((col: { field: string }) => {
@@ -102,130 +149,29 @@ function getFilteredApps(apps: any[], namespace: string): any[] {
   );
 }
 
-// Define all possible columns with their properties and formatters. 
-// We'll filter this list based on window width to determine which columns to show.
-const allColumns = [
-  {
-    field: 'stateDisplay',
-    label: 'State',
-    width: '125px',
-    formatter: (_value: string, row: any) => makeStateTag(row)
-  },
-  {
-    field: 'nameDisplay',
-    label: 'Name',
-    width: '180px',
-    link: (row: any) => {
-      try {
-        return router.resolve(row.detailLocation).href;
-      } catch {
-        return '#';
-      }
-    }
-  },
-  {
-    field: 'deployment.status',
-    label: 'Status',
-    width: '75px',
-  },
-  {
-    field: 'route',
-    label: 'Routes',
-    width: '180px',
-    sortable: false,
-    formatter: (_value: any, row: any) => makeAppRoutesCell(row)
-  },
-  {
-    field: 'boundConfigs',
-    label: 'Bound Configs',
-    width: '180px',
-    sortable: false,
-    formatter: (_value: any, row: any) => makeRouterLinksOrEmpty(row.allConfigurations, router)
-  },
-  {
-    field: 'boundServices',
-    label: 'Bound Services',
-    width: '180px',
-    sortable: false,
-    formatter: (_value: any, row: any) => makeBoundServicesCell(row, router)
-  },
-  {
-    field: 'deployment.username',
-    label: 'Last Deployed By',
-    width: '150px',
-  },
-  {
-    field: 'meta.createdAt',
-    label: 'Age',
-    width: '50px',
-    formatter: 'age'
-  }
-];
+const handleNavigate = (event: CustomEvent) => router.push(event.detail.url);
 
-// Drop lower-priority columns at smaller window widths to avoid horizontal scrolling.
-//   < 875px: show only State and Name
-//   <1100px: all columns except Routes
-//   <1275px: all columns except Routes, Bound Configs, and Bound Services
-//   <1500px: all columns except Last Deployed By
-//   <1700px: all columns
-const columns = computed(() => {
-  const w = windowWidth.value;
-  const hide = new Set<string>();
-
-  if (w < 1700) {
-    hide.add('deployment.username');
-  }
-  if (w < 1500) {
-    hide.add('deployment.status');
-  }
-  if (w < 1275) {
-    hide.add('boundConfigs');
-    hide.add('boundServices');
-  }
-  if (w < 1100) {
-    hide.add('meta.createdAt');
-  }
-  if (w < 875) {
-    hide.add('route');
-  }
-
-  return allColumns.filter(col => !hide.has(col.field));
-});
-
-// Handle internal navigation events emitted by trailhand-table link cells
-const handleNavigate = (event: CustomEvent) => {
-  const { url } = event.detail;
-
-  router.push(url);
-};
+// Lifecycle
+// Initial fetch of all apps, then start polling.
 
 onMounted(async () => {
   window.addEventListener('resize', onResize);
+
+  // ONE global fetch: no page params so backend returns all apps.
   await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.APP });
-  // Non-blocking fetch
+
+  // Non-blocking: needed for bound-resource columns.
   store.dispatch('epinio/findAll', { type: EPINIO_TYPES.CONFIGURATION });
   store.dispatch('epinio/findAll', { type: EPINIO_TYPES.SERVICE_INSTANCE });
 
   pending.value = false;
-  startPolling(
-    [
-      'namespaces',
-      'applications',
-      'configurations',
-      'services',
-    ],
-    store
-  );
+
+  startPolling(['namespaces', 'applications', 'configurations', 'services'], store);
 });
 
 onUnmounted(() => {
   window.removeEventListener('resize', onResize);
-  stopPolling([
-    'namespaces',
-    'applications',
-    'configurations',
-    'services'
-  ]);
+  stopPolling(['namespaces', 'applications', 'configurations', 'services']);
 });
 </script>
 
@@ -248,16 +194,16 @@ onUnmounted(() => {
     </Masthead>
 
     <div
-      v-for="(apps, namespace) in groupedByNamespace"
-      :key="namespace"
+      v-for="ns in namespacesWithApps"
+      :key="ns"
       class="namespace-group"
     >
       <div class="namespace-group-header">
         <h3 class="namespace-header">
-          Namespace: <span class="namespace-name">{{ namespace }}</span>
+          Namespace: <span class="namespace-name">{{ ns }}</span>
         </h3>
         <input
-          v-model="searchQueries[namespace]"
+          v-model="searchQueries[ns]"
           type="text"
           class="namespace-search-input"
           placeholder="Search..."
@@ -266,15 +212,10 @@ onUnmounted(() => {
 
       <trailhand-table
         :ref="(el: any) => { if (el) el.renderActions = makeActionMenu; }"
-        :rows="getFilteredApps(apps, String(namespace))"
+        :rows="getFilteredApps(groupedByNamespace[ns], ns)"
         :columns="columns"
         :searchable="false"
-        :total-items="store.getters['epinio/paginationMeta'](resource)?.totalItems ?? store.getters['epinio/all'](resource).length"
-        :loading="paginating[namespace]"
-        :server-side="!!store.getters['epinio/paginationMeta'](resource)"
-        rows-per-page="10"
         @navigate="handleNavigate"
-        @page-change="(e: CustomEvent) => handlePageChange(e, String(namespace))"
       />
     </div>
   </div>
@@ -288,13 +229,11 @@ onUnmounted(() => {
     margin-bottom: 0;
   }
 
-  // Map Rancher shell's hover variable name to what trailhand-table expects
-  // CSS custom properties inherit into shadow DOM, fixing the dark mode white flash
   trailhand-table {
     --sortable-table-row-hover-bg: var(--sortable-table-hover-bg);
     --sortable-table-header-hover-bg: var(--sortable-table-hover-bg);
     --sortable-table-header-sorted-bg: var(--sortable-table-hover-bg);
-    overflow-wrap: anywhere; // inherited into shadow DOM — prevents long strings from overflowing column boundaries
+    overflow-wrap: anywhere;
   }
 }
 

--- a/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
@@ -191,32 +191,45 @@ const handleNavigate = (event: CustomEvent) => router.push(event.detail.url);
 
 // Lifecycle
 
+// Applications are never loaded via the unpaginated findAll. They come in
+// exclusively through findAppsInNamespace (per-namespace, paginated).
+let appsPollIntervalId: number | undefined;
+const APPS_POLL_RATE_MS = 30000;
+
+function visibleNamespaceNames(): string[] {
+  return (store.getters['epinio/all'](EPINIO_TYPES.NAMESPACE) as any[])
+    .map((ns: any) => ns.meta?.name)
+    .filter((n: string) => !!n);
+}
+
 onMounted(async () => {
   window.addEventListener('resize', onResize);
 
-  // ONE global fetch, no page params so backend returns all apps.
-  await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.APP });
+  pending.value = false;
 
-  // Non-blocking: needed for bound-resource columns.
+  // Seed each namespace's first paginated page. loadCluster has already
+  // awaited findAll(NAMESPACE), so the list is available.
+  visibleNamespaceNames().forEach(ns => fetchNamespaceApps(ns, 1, false));
   store.dispatch('epinio/findAll', { type: EPINIO_TYPES.CONFIGURATION });
   store.dispatch('epinio/findAll', { type: EPINIO_TYPES.SERVICE_INSTANCE });
 
-  pending.value = false;
+  // Poll supporting resources
+  startPolling(['namespaces', 'configurations', 'services'], store);
 
-  // Background: silently fetch page 1 per namespace to populate pagination
-  // meta. No loading overlays, initial display from global data is already
-  // visible. Fires AFTER pending=false so the tables are already rendered.
-  const seenNamespaces = Object.keys(groupedByNamespace.value);
-
-  seenNamespaces.forEach(ns => fetchNamespaceApps(ns, 1, true));
-
-  // ONE global poll per cycle, not one per namespace.
-  startPolling(['namespaces', 'applications', 'configurations', 'services'], store);
+  // Poll apps per namespace at their current page.
+  appsPollIntervalId = window.setInterval(() => {
+    visibleNamespaceNames().forEach(ns => {
+      fetchNamespaceApps(ns, namespaceCurrentPages.value[ns] ?? 1, true);
+    });
+  }, APPS_POLL_RATE_MS);
 });
 
 onUnmounted(() => {
   window.removeEventListener('resize', onResize);
-  stopPolling(['namespaces', 'applications', 'configurations', 'services']);
+  stopPolling(['namespaces', 'configurations', 'services']);
+  if (appsPollIntervalId !== undefined) {
+    window.clearInterval(appsPollIntervalId);
+  }
 });
 </script>
 

--- a/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
@@ -67,6 +67,17 @@ const groupedByNamespace = computed(() => {
 });
 
 const pending = ref(true);
+const paginating = ref<Record<string, boolean>>({});
+
+const handlePageChange = async(e: CustomEvent, namespace: string) => {
+  if (paginating.value[namespace]) return;
+  paginating.value = { ...paginating.value, [namespace]: true };
+  try {
+    await store.dispatch('epinio/goToPage', { type: resource, page: e.detail.page });
+  } finally {
+    paginating.value = { ...paginating.value, [namespace]: false };
+  }
+};
 
 // Per-namespace search queries (keyed by namespace name)
 const searchQueries = ref<Record<string, string>>({});
@@ -258,7 +269,12 @@ onUnmounted(() => {
         :rows="getFilteredApps(apps, String(namespace))"
         :columns="columns"
         :searchable="false"
+        :total-items="store.getters['epinio/paginationMeta'](resource)?.totalItems ?? store.getters['epinio/all'](resource).length"
+        :loading="paginating[namespace]"
+        :server-side="!!store.getters['epinio/paginationMeta'](resource)"
+        rows-per-page="10"
         @navigate="handleNavigate"
+        @page-change="(e: CustomEvent) => handlePageChange(e, String(namespace))"
       />
     </div>
   </div>

--- a/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
@@ -31,8 +31,10 @@ const openCreateRoute = () => router.push(createLocation.value);
 
 const pending = ref(true);
 
-// Global state
-// Touch stateDisplay and meta to ensure reactivity with _MERGE polling that replaces all properties.
+// ── Global store rows ────────────────────────────────────────────────────────
+// ONE global findAll seeds the initial display instantly (no page params →
+// backend returns all apps). Touch reactive properties so _MERGE polling
+// updates that mutate items in-place are tracked by Vue.
 const rows = computed(() => {
   const all = store.getters['epinio/all'](EPINIO_TYPES.APP) as any[];
 
@@ -41,10 +43,9 @@ const rows = computed(() => {
   return [...all];
 });
 
-// Groups all apps by namespace, respecting the active namespace filter.
+// Groups all apps by namespace respecting the active namespace filter.
 const groupedByNamespace = computed(() => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const _cacheKey = store.state.activeNamespaceCacheKey;
+  void store.state.activeNamespaceCacheKey;
   const activeNamespaces = store.state.activeNamespaceCache;
   const groups: Record<string, any[]> = {};
 
@@ -59,15 +60,53 @@ const groupedByNamespace = computed(() => {
   return groups;
 });
 
-// Sorted list of namespaces that have at least one app.
-const namespacesWithApps = computed(() =>
-  Object.keys(groupedByNamespace.value)
-    .filter(ns => groupedByNamespace.value[ns].length > 0)
-    .sort()
-);
+// Per-namespace pagination state
+
+type PaginationMeta = { page: number; pageSize: number; totalItems: number; totalPages: number };
+
+const namespaceRows         = ref<Record<string, any[]>>({});
+const namespaceLoading      = ref<Record<string, boolean>>({});
+const namespaceMeta         = ref<Record<string, PaginationMeta | null>>({});
+const namespaceCurrentPages = ref<Record<string, number>>({});
+
+// Returns the best available rows for a namespace: namespace-specific once
+// fetched, global store rows before that (instant initial display).
+function getDisplayRows(ns: string): any[] {
+  return namespaceRows.value[ns] ?? groupedByNamespace.value[ns] ?? [];
+}
+
+// silent=true → skip loading overlay (polling and background meta seeding)
+async function fetchNamespaceApps(namespace: string, page = 1, silent = false) {
+  if (!silent) {
+    namespaceLoading.value = { ...namespaceLoading.value, [namespace]: true };
+  }
+  namespaceCurrentPages.value = { ...namespaceCurrentPages.value, [namespace]: page };
+
+  try {
+    const { items, meta } = await store.dispatch('epinio/findAppsInNamespace', { namespace, page });
+
+    namespaceRows.value = { ...namespaceRows.value, [namespace]: items };
+    namespaceMeta.value = { ...namespaceMeta.value, [namespace]: meta };
+  } finally {
+    if (!silent) {
+      namespaceLoading.value = { ...namespaceLoading.value, [namespace]: false };
+    }
+  }
+}
+
+async function handlePageChange(event: CustomEvent, namespace: string) {
+  await fetchNamespaceApps(namespace, event.detail.page);
+}
+
+// Only render namespace groups that have apps in either source.
+const namespacesWithApps = computed(() => {
+  const fromGlobal   = Object.keys(groupedByNamespace.value).filter(ns => groupedByNamespace.value[ns].length > 0);
+  const fromSpecific = Object.keys(namespaceRows.value).filter(ns => (namespaceRows.value[ns]?.length ?? 0) > 0);
+
+  return [...new Set([...fromGlobal, ...fromSpecific])].sort();
+});
 
 // Responsive columns
-// Touch windowWidth to trigger recomputation on resize
 
 const windowWidth = ref(window.innerWidth);
 const onResize = () => { windowWidth.value = window.innerWidth; };
@@ -127,7 +166,6 @@ const columns = computed(() => {
 });
 
 // Per-namespace search
-// Stores the search query for each namespace group. Keys are namespace names, values are the current search query for that namespace.
 
 const searchQueries = ref<Record<string, string>>({});
 
@@ -152,12 +190,11 @@ function getFilteredApps(apps: any[], namespace: string): any[] {
 const handleNavigate = (event: CustomEvent) => router.push(event.detail.url);
 
 // Lifecycle
-// Initial fetch of all apps, then start polling.
 
 onMounted(async () => {
   window.addEventListener('resize', onResize);
 
-  // ONE global fetch: no page params so backend returns all apps.
+  // ONE global fetch, no page params so backend returns all apps.
   await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.APP });
 
   // Non-blocking: needed for bound-resource columns.
@@ -166,6 +203,14 @@ onMounted(async () => {
 
   pending.value = false;
 
+  // Background: silently fetch page 1 per namespace to populate pagination
+  // meta. No loading overlays, initial display from global data is already
+  // visible. Fires AFTER pending=false so the tables are already rendered.
+  const seenNamespaces = Object.keys(groupedByNamespace.value);
+
+  seenNamespaces.forEach(ns => fetchNamespaceApps(ns, 1, true));
+
+  // ONE global poll per cycle, not one per namespace.
   startPolling(['namespaces', 'applications', 'configurations', 'services'], store);
 });
 
@@ -210,12 +255,23 @@ onUnmounted(() => {
         >
       </div>
 
+      <!--
+        server-side becomes true once per-namespace meta arrives.
+        Until then the table shows up to 10 global rows with no pagination
+        controls (never more than one page worth). Loading overlay only
+        appears on explicit user-initiated page changes, not polling.
+      -->
       <trailhand-table
         :ref="(el: any) => { if (el) el.renderActions = makeActionMenu; }"
-        :rows="getFilteredApps(groupedByNamespace[ns], ns)"
+        :rows="getFilteredApps(getDisplayRows(ns), ns)"
         :columns="columns"
         :searchable="false"
+        :server-side="!!namespaceMeta[ns]"
+        :total-items="namespaceMeta[ns]?.totalItems ?? 0"
+        :current-page="namespaceCurrentPages[ns] ?? 1"
+        :loading="namespaceLoading[ns] ?? false"
         @navigate="handleNavigate"
+        @page-change="(e: CustomEvent) => handlePageChange(e, ns)"
       />
     </div>
   </div>

--- a/dashboard/pkg/epinio/store/epinio-store/actions.ts
+++ b/dashboard/pkg/epinio/store/epinio-store/actions.ts
@@ -404,7 +404,7 @@ export default {
 
     // classify() instantiates the proper model class so computed properties
     // (stateDisplay, nameDisplay, detailLocation, allConfigurations, etc.)
-    // are available for the column formatters — same as what findAll does.
+    // are available for the column formatters, same as what findAll does.
     const items = rawItems.map((item: any) => classify(ctx, item));
 
     return {

--- a/dashboard/pkg/epinio/store/epinio-store/actions.ts
+++ b/dashboard/pkg/epinio/store/epinio-store/actions.ts
@@ -313,7 +313,6 @@ export default {
   loadCluster: async( { dispatch, commit, rootGetters }: any, { id }: any ) => {
     await dispatch(`loadSchemas`);
     await dispatch(`findAll`, { type: EPINIO_TYPES.NAMESPACE });
-    dispatch(`findAll`, { type: EPINIO_TYPES.APP }); // This is used often, get a kick start
     await dispatch('cleanNamespaces', null, { root: true });
 
     const key = createNamespaceFilterKeyWithId(id, EPINIO_PRODUCT_NAME);

--- a/dashboard/pkg/epinio/store/epinio-store/actions.ts
+++ b/dashboard/pkg/epinio/store/epinio-store/actions.ts
@@ -381,9 +381,12 @@ export default {
     return info;
   },
 
-  goToPage: async({ commit, dispatch }: any, { type, page }: SetPaginationPagePayload) => {
+  goToPage: async({ commit, dispatch, getters }: any, { type, page }: SetPaginationPagePayload) => {
     commit('setPaginationPage', { type, page });
-    await dispatch('findAll', { type, opt: { force: true } });
+    const schema = getters.schemaFor(type);
+    const url = `${ schema?.links?.collection }?page=${ page }&pageSize=10`;
+
+    await dispatch('findAll', { type, opt: { force: true, url } });
   },
 
 };

--- a/dashboard/pkg/epinio/store/epinio-store/actions.ts
+++ b/dashboard/pkg/epinio/store/epinio-store/actions.ts
@@ -130,7 +130,11 @@ export default {
               totalPages: (out as any).totalPages
             };
 
-            commit('setPaginationMeta', { type, meta: pagination });
+            // Allow callers to opt out of updating global pagination state
+            // (e.g. per-namespace fetches that maintain their own meta)
+            if (!opt._skipPaginationMeta) {
+              commit('setPaginationMeta', { type, meta: pagination });
+            }
 
             res.data = {
               data:        items.map((o: any) => epiniofy(o, schema, type)),
@@ -381,12 +385,37 @@ export default {
     return info;
   },
 
-  goToPage: async({ commit, dispatch, getters }: any, { type, page }: SetPaginationPagePayload) => {
-    commit('setPaginationPage', { type, page });
-    const schema = getters.schemaFor(type);
-    const url = `${ schema?.links?.collection }?page=${ page }&pageSize=10`;
+  /**
+   * Fetch a single page of applications scoped to a specific namespace.
+   * Does NOT touch global paginationMeta so per-namespace tables stay independent.
+   * Returns { items: any[], meta: { page, pageSize, totalItems, totalPages } | null }
+   */
+  findAppsInNamespace: async(ctx: any, { namespace, page = 1 }: { namespace: string; page?: number }) => {
+    const { dispatch } = ctx;
+    const result = await dispatch('request', {
+      opt: {
+        url:                 `/api/v1/namespaces/${ namespace }/applications?page=${ page }&pageSize=10`,
+        _skipPaginationMeta: true,
+      },
+      type: EPINIO_TYPES.APP,
+    });
 
-    await dispatch('findAll', { type, opt: { force: true, url } });
+    const rawItems: any[] = result?.data ?? [];
+
+    // classify() instantiates the proper model class so computed properties
+    // (stateDisplay, nameDisplay, detailLocation, allConfigurations, etc.)
+    // are available for the column formatters — same as what findAll does.
+    const items = rawItems.map((item: any) => classify(ctx, item));
+
+    return {
+      items,
+      meta: result?._pagination ?? null,
+    };
+  },
+
+  goToPage: async({ commit, dispatch }: any, { type, page }: SetPaginationPagePayload) => {
+    commit('setPaginationPage', { type, page });
+    await dispatch('findAll', { type, opt: { force: true } });
   },
 
 };

--- a/dashboard/pkg/epinio/store/epinio-store/getters.ts
+++ b/dashboard/pkg/epinio/store/epinio-store/getters.ts
@@ -40,8 +40,7 @@ export default {
     return url;
   },
 
-  urlOptions: () => (url: any) => {
-    // This is where Epinio API filter, limit, sort will be applied
+  urlOptions: (_state: any) => (url: any) => {
     return url;
   },
 

--- a/dashboard/pkg/epinio/store/epinio-store/getters.ts
+++ b/dashboard/pkg/epinio/store/epinio-store/getters.ts
@@ -40,14 +40,47 @@ export default {
     return url;
   },
 
-  urlOptions: (_state: any) => (url: any) => {
+  // Ensure pagination params are included in URLs for list fetches, based on global pagination state for that type. 
+  // This allows pagination to work with any component that uses urlFor to generate its API URLs, without needing to explicitly pass page params from the component.
+  urlOptions: (state: any) => (url: any) => {
+    const pathToType: Record<string, string> = {
+      '/api/v1/appcharts':      EPINIO_TYPES.APP_CHARTS,
+      '/api/v1/namespaces':     EPINIO_TYPES.NAMESPACE,
+      '/api/v1/configurations': EPINIO_TYPES.CONFIGURATION,
+      '/api/v1/services':       EPINIO_TYPES.SERVICE_INSTANCE,
+    };
+
+    const [path, query = ''] = String(url).split('?');
+
+    if (path in pathToType) {
+      const params = new URLSearchParams(query);
+      const type = pathToType[path];
+      const currentPage = state.paginationPage?.[type] ?? 1;
+
+      if (!params.has('page')) {
+        params.set('page', String(currentPage));
+      }
+      if (!params.has('pageSize')) {
+        params.set('pageSize', '10');
+      }
+
+      const qs = params.toString();
+
+      return qs ? `${ path }?${ qs }` : path;
+    }
+
     return url;
   },
 
+  // Return pagination meta for the given type, or null if not set. 
+  // This is used by components to read pagination state for their API calls, which is managed globally in the store.
   paginationMeta: (state: any) => (type: string) => state.paginationMeta?.[type] ?? null,
 
+  // Return the current page number for the given type, or 1 if not set.
   currentPaginationPage: (state: any) => (type: string) => state.paginationPage?.[type] ?? 1,
 
+  // Namespace filter options for the UI. Uses the addNamespace and divider helpers passed from the component to build the list
+  // of options, which includes an "All namespaces" option followed by a divider and then individual namespaces.
   namespaceFilterOptions: (state: any, getters: any, rootState: any, rootGetters: any) => ({
     addNamespace,
     divider


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [ ] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
<!-- wire up server-side pagination between trailhand-table and the Epinio backend -->

Adds server-side pagination support across all Epinio list tables (configurations, services, namespaces, app charts) and per-namespace pagination for the applications view. The `trailhand-table` `page-change` event is now consumed by each list component, which dispatches to a new Vuex `goToPage` action that re-fetches the correct page from the API.

### Occurred changes and/or fixed issues

- **Store** (`epinio-store`): added `paginationPage` and `paginationMeta` state slices, `setPaginationPage` / `setPaginationMeta` mutations, `urlOptions` getter that injects `page` / `pageSize` query params into API URLs automatically, `paginationMeta` and `currentPaginationPage` getters, `goToPage` action, and `findAppsInNamespace` action for per-namespace fetches that bypass global meta.
- **`request` action**: detects paginated API responses (shape `{ items, page, pageSize, totalItems, totalPages }`), commits `setPaginationMeta`, and returns `_pagination` alongside row data. Callers can opt out via `_skipPaginationMeta`.
- **All list tables** (`configurations`, `services`, `namespaces`, `appcharts`): read `paginationMeta` from the store, pass `:server-side`, `:total-items`, and `:current-page` props to `trailhand-table`, and handle `@page-change` by calling `goToPage`.
- **Applications index page**: uses a two-phase strategy. One global `findAll` (no page params) for instant initial render, followed by silent per-namespace background fetches to seed pagination meta. Subsequent `@page-change` events trigger per-namespace refetches without a global loading overlay.

### Technical notes summary

- `urlOptions` acts as a transparent middleware: any `urlFor` call for a known type (`/api/v1/appcharts`, `/api/v1/namespaces`, `/api/v1/configurations`, `/api/v1/services`) automatically receives current page params from store state, so no component needs to manually construct paginated URLs.
- The applications page deliberately avoids using `urlOptions` for its per-namespace calls. It builds the URL directly with the namespace path and `_skipPaginationMeta: true` to keep each namespace table's meta isolated from the global pagination state.
- `goToPage` is a simple two-step: commit the new page number to state (which `urlOptions` will read), then force a `findAll` refetch.
- Before this PR, `trailhand-table` had no `page-change` event. The Lit component's `goToPage` method was updated upstream to `dispatchEvent(new CustomEvent('page-change', { detail: { page }, bubbles: true, composed: true }))`.

### Areas or cases that should be tested

- **Each list view** (Configurations, Services, Namespaces, App Charts): navigate to page 2+, confirm the correct rows load and the URL sent to the API includes the right `page` and `pageSize` params.
- **Applications view**: verify initial load shows rows immediately from global data, then per-namespace pagination controls appear once background meta fetch completes. Navigate between pages within a namespace without affecting other namespace tables.
- **Namespace filter**: switch namespace filter while on page 2 of a list and confirm the table resets to page 1.
- **Empty / last page**: confirm behavior when a page has fewer than 10 items (last page) or zero items.
- **Browser tested locally**: <!-- add your browser here -->

### Areas which could experience regressions

- **Any list table that calls `urlFor`**: `urlOptions` now silently appends `page`/`pageSize` for the four registered paths. If a type shares a URL path prefix with those paths, it could inadvertently get pagination params.
- **`request` action response parsing**: the new branch that detects `items` array shape changes the `res.data` structure for paginated responses. Any code that previously destructured `res.data` directly (expecting a flat array) from those endpoints may break.
- **Applications global `findAll`**: this call intentionally has no page params (returns all apps for namespace grouping). Confirm `urlOptions` does not inject params for `/api/v1/applications` (it is not in the `pathToType` map).
- **Polling**: `startPolling` triggers `findAll` in the background. Confirm these background re-fetches respect the current `paginationPage` state rather than resetting to page 1.

### Screenshot/Video
<!-- Attach screenshot or video of the pagination controls in each list table -->
