### PR TITLE
Feat/bulk delete UI

### DIFF
--- a/dashboard/pkg/epinio/components/BulkDeleteModal.vue
+++ b/dashboard/pkg/epinio/components/BulkDeleteModal.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { useStore } from 'vuex';
+import { Card } from '@components/Card';
+import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
+
+interface Props {
+  show: boolean;
+  title: string;
+  itemLabels: string[];
+  deleting?: boolean;
+  showDeleteImage?: boolean;
+  description?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  deleting: false,
+  showDeleteImage: false,
+  description: ''
+});
+
+const emit = defineEmits<{
+  (event: 'close'): void;
+  (event: 'confirm', payload: { deleteImage: boolean }): void;
+}>();
+
+const deleteImage = ref(false);
+const store = useStore();
+const t = store.getters['i18n/t'];
+
+watch(() => props.show, (show) => {
+  if (!show) {
+    deleteImage.value = false;
+  }
+});
+
+function onConfirm() {
+  emit('confirm', { deleteImage: deleteImage.value });
+}
+</script>
+
+<template>
+  <div
+    v-if="show"
+    class="modal"
+  >
+    <Card
+      class="modal-content"
+      :show-actions="true"
+    >
+      <template #title>
+        <h4>{{ title }}</h4>
+      </template>
+      <template #body>
+        <p class="mb-10">{{ description }}</p>
+        <ul class="delete-list">
+          <li
+            v-for="label in itemLabels"
+            :key="label"
+          >
+            {{ label }}
+          </li>
+        </ul>
+        <div
+          v-if="showDeleteImage"
+          class="mt-20"
+        >
+          <Checkbox
+            v-model:value="deleteImage"
+            :label="t('epinio.applications.deleteImage.label')"
+          />
+        </div>
+      </template>
+      <template #actions>
+        <div class="modal-actions">
+          <button
+            class="btn role-secondary mr-10"
+            :disabled="deleting"
+            @click="$emit('close')"
+          >
+            {{ t('generic.cancel') }}
+          </button>
+          <button
+            class="btn bulk-delete-confirm-btn"
+            :disabled="deleting || itemLabels.length === 0"
+            @click="onConfirm"
+          >
+            {{ deleting ? t('epinio.bulkDelete.deletingAction') : t('epinio.bulkDelete.confirmAction', { count: itemLabels.length }) }}
+          </button>
+        </div>
+      </template>
+    </Card>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.modal {
+  position: fixed;
+  z-index: 50;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-radius: var(--border-radius);
+}
+
+.modal-content {
+  background-color: var(--default);
+  margin: 10% auto;
+  padding: 20px;
+  border: 1px solid #888;
+  width: 50%;
+  max-width: 650px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.delete-list {
+  max-height: 220px;
+  overflow: auto;
+  margin: 0;
+  padding-left: 20px;
+}
+
+.bulk-delete-confirm-btn:disabled {
+  background-color: var(--disabled-bg) !important;
+  border-color: var(--border) !important;
+  color: var(--disabled-text) !important;
+  opacity: 1;
+}
+
+.bulk-delete-confirm-btn:not(:disabled) {
+  background-color: var(--error) !important;
+  border-color: var(--error) !important;
+  color: var(--error-contrast, #fff) !important;
+}
+
+.bulk-delete-confirm-btn:not(:disabled):hover {
+  filter: brightness(0.92);
+}
+</style>

--- a/dashboard/pkg/epinio/components/tables/DataTable.vue
+++ b/dashboard/pkg/epinio/components/tables/DataTable.vue
@@ -16,6 +16,8 @@ interface Props {
   keyField?: string;
   rowActions?: boolean;
   rowActionsWidth?: number;
+  selectable?: boolean;
+  selectedRowKeys?: string[];
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -26,8 +28,15 @@ const props = withDefaults(defineProps<Props>(), {
   loading: false,
   keyField: 'id',
   rowActions: true,
-  rowActionsWidth: 40
+  rowActionsWidth: 40,
+  selectable: false,
+  selectedRowKeys: () => []
 });
+
+const emit = defineEmits<{
+  (event: 'selection-change', selectedRows: DataTableRow[]): void;
+  (event: 'update:selectedRowKeys', selectedRowKeys: string[]): void;
+}>();
 
 // Define slot types - using Record<string, any> for row to allow dynamic properties
 defineSlots<{
@@ -40,6 +49,8 @@ const searchQuery = ref('');
 const currentPage = ref(1);
 const sortColumn = ref<string | null>(null);
 const sortDirection = ref<SortDirection>('asc');
+const internalSelectedKeys = ref<Set<string>>(new Set());
+const selectAllCheckbox = ref<HTMLInputElement | null>(null);
 const store = useStore();
 
 // Apply namespace filter first
@@ -146,6 +157,24 @@ const paginationInfo = computed(() => {
   };
 });
 
+const allVisibleSelected = computed(() => {
+  if (!props.selectable || !paginatedRows.value.length) {
+    return false;
+  }
+
+  return paginatedRows.value.every((row) => internalSelectedKeys.value.has(getRowKey(row, 0)));
+});
+
+const someVisibleSelected = computed(() => {
+  if (!props.selectable || !paginatedRows.value.length) {
+    return false;
+  }
+
+  const selectedCount = paginatedRows.value.filter((row) => internalSelectedKeys.value.has(getRowKey(row, 0))).length;
+
+  return selectedCount > 0 && selectedCount < paginatedRows.value.length;
+});
+
 // Methods
 function getNestedValue(obj: any, path: string): any {
   return path.split('.').reduce((current, key) => current?.[key], obj);
@@ -201,12 +230,73 @@ function prevPage() {
 }
 
 function getRowKey(row: DataTableRow, index: number): string {
-  return row[props.keyField] || `row-${index}`;
+  return String(row[props.keyField] || `row-${index}`);
+}
+
+function syncSelectionToRows() {
+  const selected = props.rows.filter((row, index) => internalSelectedKeys.value.has(getRowKey(row, index)));
+  const keys = selected.map((row, index) => getRowKey(row, index));
+
+  emit('selection-change', selected);
+  emit('update:selectedRowKeys', keys);
+}
+
+function toggleRowSelection(row: DataTableRow, index: number, selected: boolean) {
+  const rowKey = getRowKey(row, index);
+
+  if (selected) {
+    internalSelectedKeys.value.add(rowKey);
+  } else {
+    internalSelectedKeys.value.delete(rowKey);
+  }
+
+  syncSelectionToRows();
+}
+
+function toggleSelectAllVisible(selected: boolean) {
+  paginatedRows.value.forEach((row, index) => {
+    const rowKey = getRowKey(row, index);
+
+    if (selected) {
+      internalSelectedKeys.value.add(rowKey);
+    } else {
+      internalSelectedKeys.value.delete(rowKey);
+    }
+  });
+
+  syncSelectionToRows();
 }
 
 // Watch: Reset to page 1 when search or sort changes
 watch([searchQuery, sortColumn, sortDirection], () => {
   currentPage.value = 1;
+});
+
+watch(
+  () => props.rows,
+  (newRows) => {
+    const validKeys = new Set(newRows.map((row, index) => getRowKey(row, index)));
+    internalSelectedKeys.value.forEach((key) => {
+      if (!validKeys.has(key)) {
+        internalSelectedKeys.value.delete(key);
+      }
+    });
+  },
+  { deep: true }
+);
+
+watch(
+  () => props.selectedRowKeys,
+  (newKeys) => {
+    internalSelectedKeys.value = new Set(newKeys || []);
+  },
+  { immediate: true }
+);
+
+watch([allVisibleSelected, someVisibleSelected], () => {
+  if (selectAllCheckbox.value) {
+    selectAllCheckbox.value.indeterminate = someVisibleSelected.value;
+  }
 });
 
 // Expose methods for parent components
@@ -247,6 +337,17 @@ defineExpose({
       <table class="data-table__table">
         <thead class="data-table__thead">
           <tr>
+            <th
+              v-if="selectable"
+              class="data-table__th data-table__th--select"
+            >
+              <input
+                ref="selectAllCheckbox"
+                type="checkbox"
+                :checked="allVisibleSelected"
+                @change="toggleSelectAllVisible(($event.target as HTMLInputElement).checked)"
+              >
+            </th>
             <th
               v-for="column in columns"
               :key="column.field"
@@ -290,6 +391,16 @@ defineExpose({
             class="data-table__tr"
           >
             <td
+              v-if="selectable"
+              class="data-table__td data-table__td--select"
+            >
+              <input
+                type="checkbox"
+                :checked="internalSelectedKeys.has(getRowKey(row, index))"
+                @change="toggleRowSelection(row, index, ($event.target as HTMLInputElement).checked)"
+              >
+            </td>
+            <td
               v-for="column in columns"
               :key="column.field"
               class="data-table__td"
@@ -318,7 +429,7 @@ defineExpose({
 
           <!-- Empty state -->
           <tr v-if="paginatedRows.length === 0" class="data-table__empty">
-            <td :colspan="rowActions ? columns.length + 1 : columns.length" class="data-table__td--empty">
+            <td :colspan="(rowActions ? columns.length + 1 : columns.length) + (selectable ? 1 : 0)" class="data-table__td--empty">
               <slot name="empty">
                 <span class="text-muted">
                   {{ searchQuery ? 'No results found' : 'No data available' }}
@@ -465,6 +576,12 @@ defineExpose({
       width: 40px;
       padding: 0.75rem 0.5rem;
     }
+
+    &--select {
+      width: 40px;
+      text-align: center;
+      padding: 0.75rem 0.5rem;
+    }
   }
 
   &__th-content {
@@ -509,6 +626,13 @@ defineExpose({
     }
 
     &--actions {
+      width: 40px;
+      padding: 0.5rem;
+      text-align: center;
+      vertical-align: middle;
+    }
+
+    &--select {
       width: 40px;
       padding: 0.5rem;
       text-align: center;

--- a/dashboard/pkg/epinio/components/tables/DataTable.vue
+++ b/dashboard/pkg/epinio/components/tables/DataTable.vue
@@ -18,6 +18,7 @@ interface Props {
   rowActionsWidth?: number;
   selectable?: boolean;
   selectedRowKeys?: string[];
+  rowSelectable?: (row: DataTableRow) => boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -30,7 +31,8 @@ const props = withDefaults(defineProps<Props>(), {
   rowActions: true,
   rowActionsWidth: 40,
   selectable: false,
-  selectedRowKeys: () => []
+  selectedRowKeys: () => [],
+  rowSelectable: () => true
 });
 
 const emit = defineEmits<{
@@ -157,22 +159,24 @@ const paginationInfo = computed(() => {
   };
 });
 
+const visibleSelectableRows = computed(() => paginatedRows.value.filter((row) => isRowSelectable(row)));
+
 const allVisibleSelected = computed(() => {
-  if (!props.selectable || !paginatedRows.value.length) {
+  if (!props.selectable || !visibleSelectableRows.value.length) {
     return false;
   }
 
-  return paginatedRows.value.every((row) => internalSelectedKeys.value.has(getRowKey(row, 0)));
+  return visibleSelectableRows.value.every((row) => internalSelectedKeys.value.has(getRowKey(row, 0)));
 });
 
 const someVisibleSelected = computed(() => {
-  if (!props.selectable || !paginatedRows.value.length) {
+  if (!props.selectable || !visibleSelectableRows.value.length) {
     return false;
   }
 
-  const selectedCount = paginatedRows.value.filter((row) => internalSelectedKeys.value.has(getRowKey(row, 0))).length;
+  const selectedCount = visibleSelectableRows.value.filter((row) => internalSelectedKeys.value.has(getRowKey(row, 0))).length;
 
-  return selectedCount > 0 && selectedCount < paginatedRows.value.length;
+  return selectedCount > 0 && selectedCount < visibleSelectableRows.value.length;
 });
 
 // Methods
@@ -233,8 +237,12 @@ function getRowKey(row: DataTableRow, index: number): string {
   return String(row[props.keyField] || `row-${index}`);
 }
 
+function isRowSelectable(row: DataTableRow): boolean {
+  return props.rowSelectable ? props.rowSelectable(row) : true;
+}
+
 function syncSelectionToRows() {
-  const selected = props.rows.filter((row, index) => internalSelectedKeys.value.has(getRowKey(row, index)));
+  const selected = props.rows.filter((row, index) => isRowSelectable(row) && internalSelectedKeys.value.has(getRowKey(row, index)));
   const keys = selected.map((row, index) => getRowKey(row, index));
 
   emit('selection-change', selected);
@@ -242,6 +250,10 @@ function syncSelectionToRows() {
 }
 
 function toggleRowSelection(row: DataTableRow, index: number, selected: boolean) {
+  if (!isRowSelectable(row)) {
+    return;
+  }
+
   const rowKey = getRowKey(row, index);
 
   if (selected) {
@@ -254,7 +266,7 @@ function toggleRowSelection(row: DataTableRow, index: number, selected: boolean)
 }
 
 function toggleSelectAllVisible(selected: boolean) {
-  paginatedRows.value.forEach((row, index) => {
+  visibleSelectableRows.value.forEach((row, index) => {
     const rowKey = getRowKey(row, index);
 
     if (selected) {
@@ -275,7 +287,7 @@ watch([searchQuery, sortColumn, sortDirection], () => {
 watch(
   () => props.rows,
   (newRows) => {
-    const validKeys = new Set(newRows.map((row, index) => getRowKey(row, index)));
+    const validKeys = new Set(newRows.filter((row) => isRowSelectable(row)).map((row, index) => getRowKey(row, index)));
     internalSelectedKeys.value.forEach((key) => {
       if (!validKeys.has(key)) {
         internalSelectedKeys.value.delete(key);
@@ -344,6 +356,7 @@ defineExpose({
               <input
                 ref="selectAllCheckbox"
                 type="checkbox"
+                :disabled="visibleSelectableRows.length === 0"
                 :checked="allVisibleSelected"
                 @change="toggleSelectAllVisible(($event.target as HTMLInputElement).checked)"
               >
@@ -396,6 +409,7 @@ defineExpose({
             >
               <input
                 type="checkbox"
+                :disabled="!isRowSelectable(row)"
                 :checked="internalSelectedKeys.has(getRowKey(row, index))"
                 @change="toggleRowSelection(row, index, ($event.target as HTMLInputElement).checked)"
               >

--- a/dashboard/pkg/epinio/l10n/en-us.yaml
+++ b/dashboard/pkg/epinio/l10n/en-us.yaml
@@ -402,6 +402,21 @@ epinio:
       chartVersion: Chart Version
       appVersion: Version
       helmChart: Helm Chart
+  bulkDelete:
+    button: "Delete Selected ({count})"
+    deletingButton: "Deleting..."
+    deletingAction: "Deleting..."
+    confirmAction: "Delete {count} Item(s)"
+    descriptions:
+      applications: "The following applications will be deleted:"
+      services: "The following services will be deleted:"
+      namespaces: "The following namespaces will be deleted:"
+      configurations: "The following configurations will be deleted:"
+    titles:
+      applications: "Delete Selected Applications ({count})"
+      services: "Delete Selected Services ({count})"
+      namespaces: "Delete Selected Namespaces ({count})"
+      configurations: "Delete Selected Configurations ({count})"
   warnings:
     noNamespace: There are no namespaces. Please create one before proceeding
   login:

--- a/dashboard/pkg/epinio/list/configurations.vue
+++ b/dashboard/pkg/epinio/list/configurations.vue
@@ -6,6 +6,7 @@ import { createEpinioRoute } from '../utils/custom-routing';
 import LinkDetail from '@shell/components/formatter/LinkDetail.vue';
 import BadgeStateFormatter from '@shell/components/formatter/BadgeStateFormatter.vue';
 import Masthead from '@shell/components/ResourceList/Masthead';
+import BulkDeleteModal from '../components/BulkDeleteModal.vue';
 
 import { useStore } from 'vuex';
 import { ref, computed, onMounted, onUnmounted } from 'vue';
@@ -27,6 +28,17 @@ const createLocation = computed(() =>
 
 // Strict RBAC: only show Create when user has configuration write (hides for view_only)
 const canCreateConfiguration = computed(() => {
+  const can = store.getters['epinio/can'];
+  const perms = store.getters['epinio/permissions']?.();
+
+  if (!can || !perms || Object.keys(perms).length === 0) {
+    return false;
+  }
+
+  return can('configuration_write') || can('configuration');
+});
+
+const canDeleteConfiguration = computed(() => {
   const can = store.getters['epinio/can'];
   const perms = store.getters['epinio/permissions']?.();
 
@@ -68,6 +80,61 @@ onUnmounted(() => {
 const rows = computed(() => {
   return store.getters['epinio/all'](EPINIO_TYPES.CONFIGURATION);
 });
+const selectedConfigurationIds = ref<string[]>([]);
+const showDeleteModal = ref(false);
+const deletingSelected = ref(false);
+const selectedCount = computed(() => selectedConfigurationIds.value.length);
+
+function configKey(config: any): string {
+  return String(config?.id || `${ config?.meta?.namespace || 'default' }/${ config?.meta?.name || '' }`);
+}
+
+const selectedConfigurations = computed(() => {
+  const selectedSet = new Set(selectedConfigurationIds.value);
+  return rows.value.filter((config: any) => selectedSet.has(configKey(config)));
+});
+
+const selectedConfigurationLabels = computed(() => {
+  return selectedConfigurations.value.map((config: any) => `${ config.meta?.namespace }/${ config.meta?.name }`);
+});
+
+function selectedKeysForRows(items: any[]) {
+  const selectedSet = new Set(selectedConfigurationIds.value);
+  return items.map((item) => configKey(item)).filter((id) => selectedSet.has(id));
+}
+
+function onSelectionChange(selectedRows: any[]) {
+  selectedConfigurationIds.value = selectedRows.map((row: any) => configKey(row));
+}
+
+function openDeleteModal() {
+  if (!canDeleteConfiguration.value || selectedCount.value === 0 || deletingSelected.value) {
+    return;
+  }
+  showDeleteModal.value = true;
+}
+
+function closeDeleteModal() {
+  showDeleteModal.value = false;
+}
+
+async function deleteSelectedConfigurations() {
+  if (!selectedConfigurations.value.length || deletingSelected.value) {
+    return;
+  }
+
+  deletingSelected.value = true;
+  try {
+    await selectedConfigurations.value[0].bulkRemove(selectedConfigurations.value, {});
+    selectedConfigurationIds.value = [];
+    closeDeleteModal();
+    await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.CONFIGURATION, opt: { force: true } });
+  } catch (e: any) {
+    await store.dispatch('growl/fromError', { title: t('generic.notification.error'), err: e }, { root: true });
+  } finally {
+    deletingSelected.value = false;
+  }
+}
 
 const columns: DataTableColumn[] = [
   {
@@ -107,6 +174,14 @@ const columns: DataTableColumn[] = [
   >
     <template #createButton>
       <button
+        v-if="canDeleteConfiguration"
+        class="btn mr-10 bulk-delete-btn"
+        :disabled="selectedCount === 0 || deletingSelected"
+        @click="openDeleteModal"
+      >
+        {{ deletingSelected ? t('epinio.bulkDelete.deletingButton') : t('epinio.bulkDelete.button', { count: selectedCount }) }}
+      </button>
+      <button
         v-if="canCreateConfiguration"
         class="btn role-primary"
         @click="store.$router.push(createLocation)"
@@ -119,6 +194,9 @@ const columns: DataTableColumn[] = [
     :rows="rows"
     :columns="columns"
     :loading="pending"
+    :selectable="canDeleteConfiguration"
+    :selected-row-keys="selectedKeysForRows(rows)"
+    @selection-change="onSelectionChange"
   >
     <template #cell:stateDisplay="{ row }">
       <BadgeStateFormatter
@@ -163,4 +241,32 @@ const columns: DataTableColumn[] = [
       >&nbsp;</span>
     </template>
   </DataTable>
+  <BulkDeleteModal
+    :show="showDeleteModal && canDeleteConfiguration"
+    :title="t('epinio.bulkDelete.titles.configurations', { count: selectedConfigurations.length })"
+    :item-labels="selectedConfigurationLabels"
+    :deleting="deletingSelected"
+    :description="t('epinio.bulkDelete.descriptions.configurations')"
+    @close="closeDeleteModal"
+    @confirm="deleteSelectedConfigurations"
+  />
 </template>
+
+<style scoped lang="scss">
+.bulk-delete-btn:disabled {
+  background-color: var(--disabled-bg) !important;
+  border-color: var(--border) !important;
+  color: var(--disabled-text) !important;
+  opacity: 1;
+}
+
+.bulk-delete-btn:not(:disabled) {
+  background-color: var(--error) !important;
+  border-color: var(--error) !important;
+  color: var(--error-contrast, #fff) !important;
+}
+
+.bulk-delete-btn:not(:disabled):hover {
+  filter: brightness(0.92);
+}
+</style>

--- a/dashboard/pkg/epinio/list/configurations.vue
+++ b/dashboard/pkg/epinio/list/configurations.vue
@@ -83,7 +83,11 @@ const rows = computed(() => {
 const selectedConfigurationIds = ref<string[]>([]);
 const showDeleteModal = ref(false);
 const deletingSelected = ref(false);
-const selectedCount = computed(() => selectedConfigurationIds.value.length);
+const selectedCount = computed(() => selectedConfigurations.value.length);
+
+function canDeleteConfigurationRow(config: any): boolean {
+  return !!config?._canDelete;
+}
 
 function configKey(config: any): string {
   return String(config?.id || `${ config?.meta?.namespace || 'default' }/${ config?.meta?.name || '' }`);
@@ -91,7 +95,7 @@ function configKey(config: any): string {
 
 const selectedConfigurations = computed(() => {
   const selectedSet = new Set(selectedConfigurationIds.value);
-  return rows.value.filter((config: any) => selectedSet.has(configKey(config)));
+  return rows.value.filter((config: any) => canDeleteConfigurationRow(config) && selectedSet.has(configKey(config)));
 });
 
 const selectedConfigurationLabels = computed(() => {
@@ -100,7 +104,10 @@ const selectedConfigurationLabels = computed(() => {
 
 function selectedKeysForRows(items: any[]) {
   const selectedSet = new Set(selectedConfigurationIds.value);
-  return items.map((item) => configKey(item)).filter((id) => selectedSet.has(id));
+  return items
+    .filter((item) => canDeleteConfigurationRow(item))
+    .map((item) => configKey(item))
+    .filter((id) => selectedSet.has(id));
 }
 
 function onSelectionChange(selectedRows: any[]) {
@@ -195,6 +202,7 @@ const columns: DataTableColumn[] = [
     :columns="columns"
     :loading="pending"
     :selectable="canDeleteConfiguration"
+    :row-selectable="canDeleteConfigurationRow"
     :selected-row-keys="selectedKeysForRows(rows)"
     @selection-change="onSelectionChange"
   >

--- a/dashboard/pkg/epinio/list/namespaces.vue
+++ b/dashboard/pkg/epinio/list/namespaces.vue
@@ -14,8 +14,9 @@ import { epinioExceptionToErrorsArray } from '../utils/errors';
 import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 import { validateKubernetesName } from '@shell/utils/validators/kubernetes-name';
 import { startPolling, stopPolling } from '../utils/polling';
+import BulkDeleteModal from '../components/BulkDeleteModal.vue';
 
-defineProps<{
+const props = defineProps<{
   schema: object,
   rows: Array,
 }>();
@@ -47,6 +48,22 @@ const canCreateNamespace = computed(() => {
 
   return can('namespace_write') || can('namespace');
 });
+
+const canDeleteNamespace = computed(() => {
+  const can = store.getters['epinio/can'];
+  const perms = store.getters['epinio/permissions']?.();
+
+  if (!can || !perms || Object.keys(perms).length === 0) {
+    return false;
+  }
+
+  return can('namespace_write') || can('namespace');
+});
+
+const selectedNamespaceIds = ref<string[]>([]);
+const showDeleteModal = ref<boolean>(false);
+const deletingSelected = ref<boolean>(false);
+const selectedCount = computed(() => selectedNamespaceIds.value.length);
 
 const validationPassed = computed(() => {
   // Add here fields that need validation
@@ -156,6 +173,57 @@ function getNamespaceErrors(name) {
   return [];
 }
 
+function namespaceKey(ns: any): string {
+  return String(ns?._key || ns?.id || ns?.meta?.name || ns?.name || '');
+}
+
+const selectedNamespaces = computed(() => {
+  const selectedSet = new Set(selectedNamespaceIds.value);
+  return (props.rows || []).filter((ns: any) => selectedSet.has(namespaceKey(ns)));
+});
+
+const selectedNamespaceLabels = computed(() => {
+  return selectedNamespaces.value.map((ns: any) => ns.meta?.name || ns.name || ns.id);
+});
+
+function onNamespaceSelectionChange(selectedRows: any[]) {
+  selectedNamespaceIds.value = selectedRows.map((row: any) => namespaceKey(row));
+}
+
+function selectedKeysForRows(items: any[]) {
+  const selectedSet = new Set(selectedNamespaceIds.value);
+  return (items || []).map((item: any) => namespaceKey(item)).filter((id: string) => selectedSet.has(id));
+}
+
+function openDeleteModal() {
+  if (!canDeleteNamespace.value || selectedCount.value === 0 || deletingSelected.value) {
+    return;
+  }
+  showDeleteModal.value = true;
+}
+
+function closeDeleteModal() {
+  showDeleteModal.value = false;
+}
+
+async function deleteSelectedNamespaces() {
+  if (!selectedNamespaces.value.length || deletingSelected.value) {
+    return;
+  }
+
+  deletingSelected.value = true;
+  try {
+    await Promise.all(selectedNamespaces.value.map((ns: any) => ns.remove()));
+    selectedNamespaceIds.value = [];
+    closeDeleteModal();
+    await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.NAMESPACE, opt: { force: true } });
+  } catch (e: any) {
+    await store.dispatch('growl/fromError', { title: t('generic.notification.error'), err: e }, { root: true });
+  } finally {
+    deletingSelected.value = false;
+  }
+}
+
 const columns: DataTableColumn[] = [
   {
     field: 'meta.name',
@@ -180,10 +248,18 @@ const columns: DataTableColumn[] = [
 <template>
   <div>
     <Masthead
-      :schema="schema"
+      :schema="props.schema"
       :resource="resource"
     >
       <template #createButton>
+        <button
+          v-if="canDeleteNamespace"
+          class="btn mr-10 bulk-delete-btn"
+          :disabled="selectedCount === 0 || deletingSelected"
+          @click="openDeleteModal"
+        >
+          {{ deletingSelected ? t('epinio.bulkDelete.deletingButton') : t('epinio.bulkDelete.button', { count: selectedCount }) }}
+        </button>
         <button
           v-if="canCreateNamespace"
           class="btn role-primary"
@@ -194,9 +270,12 @@ const columns: DataTableColumn[] = [
       </template>
     </Masthead>
     <DataTable
-      :rows="rows"
+      :rows="props.rows"
       :columns="columns"
       key-field="_key"
+      :selectable="canDeleteNamespace"
+      :selected-row-keys="selectedKeysForRows(props.rows)"
+      @selection-change="onNamespaceSelectionChange"
     >
       <template #cell:stateDisplay="{ row }">
         <BadgeStateFormatter
@@ -205,6 +284,15 @@ const columns: DataTableColumn[] = [
         />
       </template>
     </DataTable>
+    <BulkDeleteModal
+      :show="showDeleteModal && canDeleteNamespace"
+      :title="t('epinio.bulkDelete.titles.namespaces', { count: selectedNamespaces.length })"
+      :item-labels="selectedNamespaceLabels"
+      :deleting="deletingSelected"
+      :description="t('epinio.bulkDelete.descriptions.namespaces')"
+      @close="closeDeleteModal"
+      @confirm="deleteSelectedNamespaces"
+    />
     <div
       v-if="showCreateModal"
       class="modal"
@@ -288,6 +376,23 @@ const columns: DataTableColumn[] = [
     flex: 1;
   }
 
+}
+
+.bulk-delete-btn:disabled {
+  background-color: var(--disabled-bg) !important;
+  border-color: var(--border) !important;
+  color: var(--disabled-text) !important;
+  opacity: 1;
+}
+
+.bulk-delete-btn:not(:disabled) {
+  background-color: var(--error) !important;
+  border-color: var(--error) !important;
+  color: var(--error-contrast, #fff) !important;
+}
+
+.bulk-delete-btn:not(:disabled):hover {
+  filter: brightness(0.92);
 }
 </style>
 

--- a/dashboard/pkg/epinio/list/services.vue
+++ b/dashboard/pkg/epinio/list/services.vue
@@ -10,6 +10,7 @@ import BadgeStateFormatter from '@shell/components/formatter/BadgeStateFormatter
 import Masthead from '@shell/components/ResourceList/Masthead';
 import { useStore } from 'vuex';
 import { startPolling, stopPolling } from '../utils/polling';
+import BulkDeleteModal from '../components/BulkDeleteModal.vue';
 
 const pending = ref(true);
 const store = useStore();
@@ -38,6 +39,17 @@ const canCreateService = computed(() => {
   return can('service_write') || can('service');
 });
 
+const canDeleteService = computed(() => {
+  const can = store.getters['epinio/can'];
+  const perms = store.getters['epinio/permissions']?.();
+
+  if (!can || !perms || Object.keys(perms).length === 0) {
+    return false;
+  }
+
+  return can('service_write') || can('service');
+});
+
 onMounted(async () => {
   await store.dispatch('epinio/me');
   await Promise.all([
@@ -59,6 +71,59 @@ onUnmounted(() => {
 const rows = computed(() => {
   return store.getters['epinio/all'](EPINIO_TYPES.SERVICE_INSTANCE);
 });
+const selectedServiceIds = ref<string[]>([]);
+const showDeleteModal = ref(false);
+const deletingSelected = ref(false);
+const selectedCount = computed(() => selectedServiceIds.value.length);
+
+function serviceKey(service: any): string {
+  return String(service?.id || `${ service?.meta?.namespace || 'default' }/${ service?.meta?.name || '' }`);
+}
+
+const selectedServices = computed(() => {
+  const selectedSet = new Set(selectedServiceIds.value);
+  return rows.value.filter((service: any) => selectedSet.has(serviceKey(service)));
+});
+
+const selectedServiceLabels = computed(() => selectedServices.value.map((service: any) => `${ service.meta?.namespace }/${ service.meta?.name }`));
+
+function selectedKeysForRows(items: any[]) {
+  const selectedSet = new Set(selectedServiceIds.value);
+  return items.map((item) => serviceKey(item)).filter((id) => selectedSet.has(id));
+}
+
+function onSelectionChange(selectedRows: any[]) {
+  selectedServiceIds.value = selectedRows.map((row: any) => serviceKey(row));
+}
+
+function openDeleteModal() {
+  if (!canDeleteService.value || selectedCount.value === 0 || deletingSelected.value) {
+    return;
+  }
+  showDeleteModal.value = true;
+}
+
+function closeDeleteModal() {
+  showDeleteModal.value = false;
+}
+
+async function deleteSelectedServices() {
+  if (!selectedServices.value.length || deletingSelected.value) {
+    return;
+  }
+
+  deletingSelected.value = true;
+  try {
+    await selectedServices.value[0].bulkRemove(selectedServices.value, {});
+    selectedServiceIds.value = [];
+    closeDeleteModal();
+    await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.SERVICE_INSTANCE, opt: { force: true } });
+  } catch (e: any) {
+    await store.dispatch('growl/fromError', { title: t('generic.notification.error'), err: e }, { root: true });
+  } finally {
+    deletingSelected.value = false;
+  }
+}
 
 const columns: DataTableColumn[] = [
   {
@@ -98,6 +163,14 @@ const columns: DataTableColumn[] = [
   >
     <template #createButton>
       <button
+        v-if="canDeleteService"
+        class="btn mr-10 bulk-delete-btn"
+        :disabled="selectedCount === 0 || deletingSelected"
+        @click="openDeleteModal"
+      >
+        {{ deletingSelected ? t('epinio.bulkDelete.deletingButton') : t('epinio.bulkDelete.button', { count: selectedCount }) }}
+      </button>
+      <button
         v-if="canCreateService"
         class="btn role-primary"
         @click="store.$router.push(createLocation)"
@@ -110,6 +183,9 @@ const columns: DataTableColumn[] = [
     :rows="rows"
     :columns="columns"
     :loading="pending"
+    :selectable="canDeleteService"
+    :selected-row-keys="selectedKeysForRows(rows)"
+    @selection-change="onSelectionChange"
   >
     <template #cell:stateDisplay="{ row }">
       <BadgeStateFormatter
@@ -150,5 +226,33 @@ const columns: DataTableColumn[] = [
       >&nbsp;</span>
     </template>
   </DataTable>
+  <BulkDeleteModal
+    :show="showDeleteModal && canDeleteService"
+    :title="t('epinio.bulkDelete.titles.services', { count: selectedServices.length })"
+    :item-labels="selectedServiceLabels"
+    :deleting="deletingSelected"
+    :description="t('epinio.bulkDelete.descriptions.services')"
+    @close="closeDeleteModal"
+    @confirm="deleteSelectedServices"
+  />
 </template>
+
+<style scoped lang="scss">
+.bulk-delete-btn:disabled {
+  background-color: var(--disabled-bg) !important;
+  border-color: var(--border) !important;
+  color: var(--disabled-text) !important;
+  opacity: 1;
+}
+
+.bulk-delete-btn:not(:disabled) {
+  background-color: var(--error) !important;
+  border-color: var(--error) !important;
+  color: var(--error-contrast, #fff) !important;
+}
+
+.bulk-delete-btn:not(:disabled):hover {
+  filter: brightness(0.92);
+}
+</style>
 

--- a/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
@@ -218,7 +218,9 @@ async function deleteSelectedApps(payload?: { deleteImage: boolean }) {
     return;
   }
 
-  if (!selectedApps.value.length) {
+  const appsToDelete = [...selectedApps.value];
+
+  if (!appsToDelete.length) {
     selectedAppIds.value = [];
     closeDeleteModal();
     return;
@@ -227,10 +229,10 @@ async function deleteSelectedApps(payload?: { deleteImage: boolean }) {
   deletingSelected.value = true;
   try {
     deleteImage.value = !!payload?.deleteImage;
-    selectedApps.value.forEach((app: any) => {
+    appsToDelete.forEach((app: any) => {
       app._deleteImage = deleteImage.value;
     });
-    await selectedApps.value[0].bulkRemove(selectedApps.value, {});
+    await appsToDelete[0].bulkRemove(appsToDelete, {});
     selectedAppIds.value = [];
     closeDeleteModal();
     await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.APP, opt: { force: true } });
@@ -240,6 +242,9 @@ async function deleteSelectedApps(payload?: { deleteImage: boolean }) {
       err: e
     }, { root: true });
   } finally {
+    appsToDelete.forEach((app: any) => {
+      delete app._deleteImage;
+    });
     deletingSelected.value = false;
   }
 }

--- a/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
@@ -8,6 +8,7 @@ import Loading from '@shell/components/Loading';
 import Masthead from '@shell/components/ResourceList/Masthead';
 import LinkDetail from '@shell/components/formatter/LinkDetail.vue';
 import BadgeStateFormatter from '@shell/components/formatter/BadgeStateFormatter.vue';
+import BulkDeleteModal from '../../../../components/BulkDeleteModal.vue';
 
 import { EPINIO_TYPES } from '../../../../types';
 import { createEpinioRoute } from '../../../../utils/custom-routing';
@@ -42,8 +43,24 @@ const canCreateApp = computed(() => {
   return can('app_create') || can('app_write') || can('app');
 });
 
+const canDeleteApp = computed(() => {
+  const can = store.getters['epinio/can'];
+  const perms = store.getters['epinio/permissions']?.();
+
+  if (!can || !perms || Object.keys(perms).length === 0) {
+    return false;
+  }
+
+  return can('app_delete') || can('app_write') || can('app');
+});
+
 const rows = computed(() => store.getters['epinio/all'](resource));
 const allNamespaces = computed(() => store.getters['epinio/all'](EPINIO_TYPES.NAMESPACE) || []);
+const selectedAppIds = ref<string[]>([]);
+const deletingSelected = ref(false);
+const showDeleteModal = ref(false);
+const deleteImage = ref(false);
+const selectedCount = computed(() => selectedAppIds.value.length);
 
 // Group applications by namespace. Include every namespace so the applications table
 // is shown even when a namespace has no applications.
@@ -160,6 +177,72 @@ onUnmounted(() => {
     'services'
   ]);
 });
+
+function appKey(app: any): string {
+  return String(app?.id || `${ app?.meta?.namespace || 'default' }/${ app?.meta?.name || '' }`);
+}
+
+function selectedKeysForRows(apps: any[]) {
+  const selectedSet = new Set(selectedAppIds.value);
+
+  return apps.map((app) => appKey(app)).filter((id) => selectedSet.has(id));
+}
+
+function onSelectionChangeForNamespace(namespaceApps: any[], selectedAppsInNamespace: any[]) {
+  const namespaceKeys = new Set(namespaceApps.map((app) => appKey(app)));
+  const selectedNamespaceKeys = new Set(selectedAppsInNamespace.map((app) => appKey(app)));
+  const remaining = selectedAppIds.value.filter((id) => !namespaceKeys.has(id));
+
+  selectedAppIds.value = [...remaining, ...Array.from(selectedNamespaceKeys)];
+}
+
+const selectedApps = computed(() => {
+  const selectedSet = new Set(selectedAppIds.value);
+  return rows.value.filter((app: any) => selectedSet.has(appKey(app)));
+});
+const selectedAppLabels = computed(() => selectedApps.value.map((app: any) => `${ app.meta?.namespace }/${ app.meta?.name }`));
+
+function openDeleteModal() {
+  if (!canDeleteApp.value || selectedCount.value === 0 || deletingSelected.value) {
+    return;
+  }
+  showDeleteModal.value = true;
+}
+
+function closeDeleteModal() {
+  showDeleteModal.value = false;
+}
+
+async function deleteSelectedApps(payload?: { deleteImage: boolean }) {
+  if (!selectedAppIds.value.length || deletingSelected.value) {
+    return;
+  }
+
+  if (!selectedApps.value.length) {
+    selectedAppIds.value = [];
+    closeDeleteModal();
+    return;
+  }
+
+  deletingSelected.value = true;
+  try {
+    deleteImage.value = !!payload?.deleteImage;
+    selectedApps.value.forEach((app: any) => {
+      app._deleteImage = deleteImage.value;
+    });
+    await selectedApps.value[0].bulkRemove(selectedApps.value, {});
+    selectedAppIds.value = [];
+    closeDeleteModal();
+    await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.APP, opt: { force: true } });
+  } catch (e: any) {
+    await store.dispatch('growl/fromError', {
+      title: t('generic.notification.error'),
+      err: e
+    }, { root: true });
+  } finally {
+    deletingSelected.value = false;
+  }
+}
 </script>
 
 <template>
@@ -170,6 +253,14 @@ onUnmounted(() => {
       :resource="resource"
     >
       <template #createButton>
+        <button
+          v-if="canDeleteApp"
+          class="btn mr-10 bulk-delete-btn"
+          :disabled="selectedCount === 0 || deletingSelected"
+          @click="openDeleteModal"
+        >
+          {{ deletingSelected ? t('epinio.bulkDelete.deletingButton') : t('epinio.bulkDelete.button', { count: selectedCount }) }}
+        </button>
         <button
           v-if="canCreateApp"
           class="btn role-primary"
@@ -189,6 +280,9 @@ onUnmounted(() => {
       <DataTable
         :rows="apps"
         :columns="columns"
+        :selectable="canDeleteApp"
+        :selected-row-keys="selectedKeysForRows(apps)"
+        @selection-change="onSelectionChangeForNamespace(apps, $event)"
       >
         <template #title>
           <h3 class="namespace-header">
@@ -276,6 +370,17 @@ onUnmounted(() => {
         </template>
       </DataTable>
     </div>
+
+    <BulkDeleteModal
+      :show="showDeleteModal && canDeleteApp"
+      :title="t('epinio.bulkDelete.titles.applications', { count: selectedApps.length })"
+      :item-labels="selectedAppLabels"
+      :deleting="deletingSelected"
+      :show-delete-image="true"
+      :description="t('epinio.bulkDelete.descriptions.applications')"
+      @close="closeDeleteModal"
+      @confirm="deleteSelectedApps"
+    />
   </div>
 </template>
 
@@ -304,5 +409,22 @@ onUnmounted(() => {
 
 .route {
   word-break: break-word;
+}
+
+.bulk-delete-btn:disabled {
+  background-color: var(--disabled-bg) !important;
+  border-color: var(--border) !important;
+  color: var(--disabled-text) !important;
+  opacity: 1;
+}
+
+.bulk-delete-btn:not(:disabled) {
+  background-color: var(--error) !important;
+  border-color: var(--error) !important;
+  color: var(--error-contrast, #fff) !important;
+}
+
+.bulk-delete-btn:not(:disabled):hover {
+  filter: brightness(0.92);
 }
 </style>


### PR DESCRIPTION
### PR Checklist
- [ ] Linting Test is passing
- [ ] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened
### Summary

Adds UI bulk delete support for Epinio resources by introducing a reusable confirmation modal and table row selection, then wiring bulk delete flows into the relevant list views. A follow-up fix also aligns the new flow with existing delete safeguards for configurations and application image deletion.

### Occurred changes and/or fixed issues
- Added a reusable `BulkDeleteModal` for confirmation flows.
- Extended the shared `DataTable` with:
  - row selection
  - select-all support
  - controlled selected row keys
  - row-level selectability
- Added bulk-delete i18n strings for button labels, titles, descriptions, and deleting states.
- Added bulk delete UI flows for:
  - Applications
  - Services
  - Configurations
  - Namespaces
- Added optional "Also delete image from registry" support for bulk application deletion.
- Fixed bulk configuration deletion so non-deletable/service-related configurations cannot be selected.
- Fixed bulk application deletion so the temporary `deleteImage` flag does not leak into later delete attempts.

### Technical notes summary
- No backend changes were required for this work; the UI reuses the existing bulk delete support already exposed through the Epinio models/endpoints.
- Application bulk delete works across namespace-grouped tables by merging selection from each namespace section into one bulk action.
- `DataTable` now supports `rowSelectable`, allowing protected rows to remain visible while preventing them from being selected.
- The safeguard follow-up keeps bulk delete behavior aligned with existing single-delete rules, especially for configurations and app image deletion behavior.
- Namespace bulk delete was included as an additional UI capability/collateral improvement.

### Areas or cases that should be tested
- Applications: select one or more apps in a namespace, open bulk delete, confirm deletion, and verify list refresh.
- Applications: select apps across multiple namespace sections, confirm deletion, and verify all selected apps are removed correctly.
- Applications: enable and disable "Also delete image from registry" and verify the choice only applies to the current delete action.
- Services: bulk delete one or more services and verify the list refreshes correctly after success/failure.
- Configurations: bulk delete normal configurations and verify service-related/protected configurations are shown but cannot be selected.
- Namespaces: bulk delete multiple namespaces and verify the list refreshes correctly afterward.
- RBAC: verify bulk delete buttons and selection checkboxes only appear for users with the required permissions.
- Shared table behavior: verify checkbox state, select-all behavior, pagination, search, and modal cancel/close behavior.


### Areas which could experience regressions
- Any page using the shared `DataTable`, especially around selection, pagination, search, sorting, and action-column layout.
- Existing single-delete flows for applications, services, configurations, and namespaces.
- Application delete flows that pass the `deleteImage` option.
- Configuration delete permissions and service-related configuration handling.
- Namespace-grouped application list behavior and cross-table selection state.

