### PR TITLE
fix: use grouped apps endpoint on initial load, fall back to per-namespace polling

### DIFF
--- a/dashboard/pkg/epinio/config/epinio.ts
+++ b/dashboard/pkg/epinio/config/epinio.ts
@@ -12,13 +12,13 @@ export const BLANK_CLUSTER = '_';
 // function to watch epinio route so css overrides only apply on epinio pages
 const watchEpinioRoute = () => {
   const observer = new MutationObserver(() => {
-    const isEpinio = window.location.pathname.includes('epinio');
+    const isEpinio = window.location.pathname.startsWith('/epinio');
     document.body.classList.toggle('epinio-active', isEpinio);
   });
 
   observer.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] });
   
-  document.body.classList.toggle('epinio-active', window.location.pathname.includes('epinio'));
+  document.body.classList.toggle('epinio-active', window.location.pathname.startsWith('/epinio'));
 }
 
 export function init($plugin: any, store: any) {

--- a/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
@@ -336,7 +336,7 @@ onUnmounted(() => {
       </template>
     </Masthead>
 
-    <div v-if="pending">
+    <div v-if="pending" class="namespace-group">
       <div class="namespace-group-header">
         <h3 class="namespace-header">
           Loading applications...
@@ -402,15 +402,15 @@ onUnmounted(() => {
 .namespace-group {
   margin-bottom: 2rem;
 
-  &:last-child {
-    margin-bottom: 0;
-  }
-
   trailhand-table {
     --sortable-table-row-hover-bg: var(--sortable-table-hover-bg);
     --sortable-table-header-hover-bg: var(--sortable-table-hover-bg);
     --sortable-table-header-sorted-bg: var(--sortable-table-hover-bg);
     overflow-wrap: anywhere;
+  }
+
+  &:last-child {
+    margin-bottom: 0;
   }
 }
 

--- a/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
@@ -283,14 +283,20 @@ function handleDeleted(app: any) {
 onMounted(async () => {
   window.addEventListener('resize', onResize);
 
-  const namespaces = visibleNamespaceNames();
-
-  await Promise.all([
+  const [,,, grouped] = await Promise.all([
     store.dispatch('epinio/me'),
     store.dispatch('epinio/findAll', { type: EPINIO_TYPES.CONFIGURATION }),
     store.dispatch('epinio/findAll', { type: EPINIO_TYPES.SERVICE_INSTANCE }),
-    ...namespaces.map(ns => fetchNamespaceApps(ns, 1, '', false)),
+    store.dispatch('epinio/findGroupedApps'),
   ]);
+
+  // ?? {} so a failed grouped fetch degrades to an empty loop rather than throwing
+  for (const [ns, nsData] of Object.entries(grouped ?? {})) {
+    const { items, meta } = nsData as { items: any[]; meta: any };
+    // spread-replace instead of direct mutation so Vue tracks the change
+    namespaceRows.value  = { ...namespaceRows.value,  [ns]: items };
+    namespaceMeta.value  = { ...namespaceMeta.value,  [ns]: meta };
+  }
 
   pending.value = false;
 

--- a/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
@@ -306,10 +306,17 @@ onMounted(async () => {
     appModal.value?.openCreate();
   }
 
-  appsPollIntervalId = window.setInterval(() => {
-    visibleNamespaceNames().forEach(ns => {
-      fetchNamespaceApps(ns, namespaceCurrentPages.value[ns] ?? 1, searchQueries.value[ns] ?? '', true);
-    });
+  appsPollIntervalId = window.setInterval(async() => {
+    // Sequential await respects per-namespace page/search state and avoids
+    // firing all calls simultaneously through the k8s client rate limiter.
+    for (const ns of visibleNamespaceNames()) {
+      await fetchNamespaceApps(
+        ns,
+        namespaceCurrentPages.value[ns] ?? 1,
+        searchQueries.value[ns] ?? '',
+        true,
+      );
+    }
   }, APPS_POLL_RATE_MS);
 });
 

--- a/dashboard/pkg/epinio/store/epinio-store/actions.ts
+++ b/dashboard/pkg/epinio/store/epinio-store/actions.ts
@@ -386,6 +386,54 @@ export default {
     return info;
   },
 
+
+  /**
+   * Fetch page 1 of apps for every namespace in a single server call.
+   * Returns a map of namespace → { items, meta } matching findAppsInNamespace's shape.
+   * Falls back to an empty map on error so the UI can degrade gracefully.
+   */
+  findGroupedApps: async(
+    ctx: any,
+    { page = 1, pageSize = 10, search = '' }: {
+      page?: number;
+      pageSize?: number;
+      search?: string
+    } = {}
+  ) => {
+    const { dispatch } = ctx;
+    let url = `/api/v1/applications/grouped?page=${ page }&pageSize=${ pageSize }`;
+    if (search) {
+      url += `&search=${ encodeURIComponent(search) }`;
+    }
+
+    // The request action runs epiniofy on the response, which spreads the namespace
+    // map and injects id/type keys. The guard below skips those non-namespace entries.
+    const grouped: Record<string, any> =
+      await dispatch('request', { opt: { url, _skipPaginationMeta: true } }) ?? {};
+
+    const appSchema = ctx.getters.schemaFor(EPINIO_TYPES.APP);
+    const result: Record<string, { items: any[]; meta: any }> = {};
+    for (const [ns, nsData] of Object.entries(grouped)) {
+      if (!nsData || typeof nsData !== 'object' || !Array.isArray((nsData as any).items)) {
+        continue;
+      }
+      const items = (nsData.items ?? []).map((item: any) =>
+        classify(ctx, epiniofy(item, appSchema, EPINIO_TYPES.APP))
+      );
+      result[ns] = {
+        items,
+        meta: {
+          page:       nsData.page,
+          pageSize:   nsData.pageSize,
+          totalItems: nsData.totalItems,
+          totalPages: nsData.totalPages,
+        },
+      };
+    }
+
+    return result;
+  },
+
   /**
    * Fetch a single page of applications scoped to a specific namespace.
    * Does NOT touch global paginationMeta so per-namespace tables stay independent.

--- a/dashboard/pkg/epinio/utils/polling.ts
+++ b/dashboard/pkg/epinio/utils/polling.ts
@@ -7,7 +7,7 @@ import { _MERGE } from '@shell/plugins/dashboard-store/actions';
 * polling on specific resource types as needed by particular lists or pages.
 */
 
-const pollingRate = 15000; //15 seconds
+const pollingRate = 30000; //30 seconds
 const polling: any = {};
 
 export function startPolling(types: string[], store: any): any {


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened


### Summary
Fixes the initial app list page performance issue where one API call was fired per namespace on load.

Pairs with epinio/epinio#3034.


### Occurred changes and/or fixed issues
- Added `findGroupedApps` store action that calls the new `/api/v1/applications/grouped` endpoint
- `onMounted` now uses `findGroupedApps` for the initial load (1 call, server-side fan-out) instead of per-namespace calls
- Per-namespace pagination and background polling continue using the existing `findAppsInNamespace` action unchanged
- Increased polling interval to reduce steady-state load on the server


### Technical notes summary
The grouped endpoint returns `map[namespace]PaginatedResponse`. The store action guards against `epiniofy` injecting non-namespace keys into the response map before classifying items.


### Areas or cases that should be tested
- App list page loads correctly across multiple namespaces
- Per-namespace table pagination still works after initial load
- Background polling still refreshes app state
- A user with no namespace access sees an empty list, not an error


### Areas which could experience regressions
- App list page initial render
- Per-namespace table pagination state
