### PR TITLE
Fix/s3 chart image recovery

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -32,4 +32,4 @@ jobs:
           commitish: main
           config-name: release-drafter.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/dashboard/pkg/epinio/config/epinio.ts
+++ b/dashboard/pkg/epinio/config/epinio.ts
@@ -17,7 +17,7 @@ const watchEpinioRoute = () => {
   });
 
   observer.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] });
-  
+
   document.body.classList.toggle('epinio-active', window.location.pathname.startsWith('/epinio'));
 }
 

--- a/dashboard/pkg/epinio/detail/applications.vue
+++ b/dashboard/pkg/epinio/detail/applications.vue
@@ -287,7 +287,7 @@ const UPDATE_INSTANCES_DEBOUNCE_MS = 2000; // 2s; adjust as needed
 let updateInstancesTimeout: number | null = null;
 
 onMounted(async () => {
-  await store.dispatch('epinio/me');
+  await store.dispatch('epinio/me'); //Need to fetch fresh rights for scaling
   await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.SERVICE_INSTANCE });
   await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.CONFIGURATION });
 

--- a/dashboard/pkg/epinio/detail/applications.vue
+++ b/dashboard/pkg/epinio/detail/applications.vue
@@ -167,7 +167,7 @@ const canEditService = computed(() => {
 const canEditConfig = computed(() => {
   const canGetter = store.getters['epinio/can'];
   return canGetter && (canGetter('configuration_write') || canGetter('configuration'));
-}); 
+});
 
 
 watchEffect(() => {
@@ -287,6 +287,7 @@ const UPDATE_INSTANCES_DEBOUNCE_MS = 2000; // 2s; adjust as needed
 let updateInstancesTimeout: number | null = null;
 
 onMounted(async () => {
+  await store.dispatch('epinio/me');
   await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.SERVICE_INSTANCE });
   await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.CONFIGURATION });
 
@@ -478,13 +479,13 @@ function formatDate(date, from) {
     </div>
 
     <h3
-      v-if="value.deployment"
+      v-if="value.deployment || value.image_url"
       class="mt-20"
     >
       {{ t('epinio.applications.detail.deployment.label') }}
     </h3>
     <div
-      v-if="value.deployment"
+      v-if="value.deployment || value.image_url"
       class="deployment"
     >
       <!-- Source information -->
@@ -593,7 +594,7 @@ function formatDate(date, from) {
                         {{ t('epinio.applications.tableHeaders.deployedBy') }}
                       </td>
                       <td class="origin-value">
-                        {{ value.deployment.username }}
+                        {{ value.deployment?.username }}
                       </td>
                     </tr>
                   </tbody>

--- a/dashboard/pkg/epinio/models/applications.js
+++ b/dashboard/pkg/epinio/models/applications.js
@@ -799,6 +799,11 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
       const { stage } = await this.stage();
       await this.forceFetch();
       this.showStagingLog(stage.id);
+      await this.waitForStaging(stage.id);
+      this.$dispatch('growl/success', {
+        title:   'Application Rebuilt Successfully!',
+        message: `${ this.meta.name } has been rebuilt successfully.`,
+      }, { root: true });
     } catch (e) {
       console.log(e);
       this.$dispatch('growl/error', {
@@ -1355,7 +1360,7 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
       this.showAppLog();
       this.$dispatch('growl/success', {
         title: 'Application Restarted!',
-        message: `The application has been restarted successfully.`,
+        message: `${ this.meta.name } has been restarted successfully.`,
       }, { root: true });
     } catch (e) {
       console.log(e);

--- a/dashboard/pkg/epinio/models/applications.js
+++ b/dashboard/pkg/epinio/models/applications.js
@@ -790,7 +790,11 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
   }
 
   async restage() {
-
+    this.$dispatch('growl/info', {
+      title: 'Attempting to Rebuild Application!',
+      message: `This may take a few moments, a window will open with live logs
+      soon.`,
+    }, { root: true });
     try {
       const { stage } = await this.stage();
       await this.forceFetch();
@@ -798,7 +802,7 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
     } catch (e) {
       console.log(e);
       this.$dispatch('growl/error', {
-        title: 'Something went wrong rebuilding...',
+        title: 'Something Went Wrong Rebuilding!',
         message: `This error occurs when there are missing resources in the
         cluster, contact your system admin to investigate the issue.`,
       }, { root: true });
@@ -1340,14 +1344,23 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
   }
 
   async restart() {
+    this.$dispatch('growl/info', {
+      title: 'Attempting to Restart Application!',
+      message: `This can take a few moments, we'll let you know once it's ready.`,
+    }, { root: true });
+
     try {
       await this.followLink('restart', { method: 'post' });
       await this.forceFetch();
       this.showAppLog();
+      this.$dispatch('growl/success', {
+        title: 'Application Restarted!',
+        message: `The application has been restarted successfully.`,
+      }, { root: true });
     } catch (e) {
       console.log(e);
       this.$dispatch('growl/error', {
-        title: 'Something went wrong restarting...',
+        title: 'Something Went Wrong Restarting!',
         message: `Can't restart the application, the image may be missing,
         reach out to your system admin to investigate the issue.`,
       }, { root: true });

--- a/dashboard/pkg/epinio/models/applications.js
+++ b/dashboard/pkg/epinio/models/applications.js
@@ -145,7 +145,6 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
   }
 
   get state() {
-    console.log(`Application ${ this.meta.namespace }/${ this.meta.name } status: ${ this.status }`);
     return STATES_MAPPED[this.status] || STATES_MAPPED.unknown;
   }
 
@@ -392,6 +391,8 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
     return this.deployment?.desiredreplicas ?? this.configuration?.instances ?? 0;
   }
 
+  //Fallback to configuration.instances if deployment.desiredreplicas is not
+  //available.
   set desiredInstances(neu) {
     if (this.deployment) {
       this.deployment.desiredreplicas = neu;
@@ -798,7 +799,7 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
       console.log(e);
       this.$dispatch('growl/error', {
         title: 'Something went wrong rebuilding...',
-        message: `This error occurs when there are missing resources in the 
+        message: `This error occurs when there are missing resources in the
         cluster, contact your system admin to investigate the issue.`,
       }, { root: true });
     }

--- a/dashboard/pkg/epinio/models/applications.js
+++ b/dashboard/pkg/epinio/models/applications.js
@@ -145,6 +145,7 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
   }
 
   get state() {
+    console.log(`Application ${ this.meta.namespace }/${ this.meta.name } status: ${ this.status }`);
     return STATES_MAPPED[this.status] || STATES_MAPPED.unknown;
   }
 
@@ -392,7 +393,12 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
   }
 
   set desiredInstances(neu) {
-    this.deployment.desiredreplicas = neu;
+    if (this.deployment) {
+      this.deployment.desiredreplicas = neu;
+    }
+    if (this.configuration) {
+      this.configuration.instances = neu;
+    }
   }
 
   get readyInstances() {
@@ -783,10 +789,19 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
   }
 
   async restage() {
-    const { stage } = await this.stage();
 
-    await this.forceFetch();
-    this.showStagingLog(stage.id);
+    try {
+      const { stage } = await this.stage();
+      await this.forceFetch();
+      this.showStagingLog(stage.id);
+    } catch (e) {
+      console.log(e);
+      this.$dispatch('growl/error', {
+        title: 'Something went wrong rebuilding...',
+        message: `This error occurs when there are missing resources in the 
+        cluster, contact your system admin to investigate the issue.`,
+      }, { root: true });
+    }
   }
 
   async exportApp(resources = this) {
@@ -1324,9 +1339,18 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
   }
 
   async restart() {
-    await this.followLink('restart', { method: 'post' });
-    await this.forceFetch();
-    this.showAppLog();
+    try {
+      await this.followLink('restart', { method: 'post' });
+      await this.forceFetch();
+      this.showAppLog();
+    } catch (e) {
+      console.log(e);
+      this.$dispatch('growl/error', {
+        title: 'Something went wrong restarting...',
+        message: `Can't restart the application, the image may be missing,
+        reach out to your system admin to investigate the issue.`,
+      }, { root: true });
+    }
   }
 
   async createManifest() {

--- a/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/applications/index.vue
@@ -265,11 +265,24 @@ const handleNavigate = (event: CustomEvent) => router.push(event.detail.url);
 let appsPollIntervalId: number | undefined;
 const APPS_POLL_RATE_MS = 30000;
 
-function visibleNamespaceNames(): string[] {
-  return (store.getters['epinio/all'](EPINIO_TYPES.NAMESPACE) as any[])
+// Keep namespaceRows in sync with the namespace store. Runs immediately on
+// mount (seeding all known namespaces) and re-runs whenever startPolling
+// updates the store with new namespaces, so new groups appear without a jump.
+watchEffect(() => {
+  const storeNs = (store.getters['epinio/all'](EPINIO_TYPES.NAMESPACE) as any[])
     .map((ns: any) => ns.meta?.name)
-    .filter((n: string) => !!n);
-}
+    .filter(Boolean) as string[];
+  const existing = namespaceRows.value;
+  const additions: Record<string, any[]> = {};
+  for (const ns of storeNs) {
+    if (!(ns in existing)) {
+      additions[ns] = [];
+    }
+  }
+  if (Object.keys(additions).length) {
+    namespaceRows.value = { ...existing, ...additions };
+  }
+});
 
 function handleDeleted(app: any) {
   const ns = app.meta.namespace;
@@ -307,9 +320,9 @@ onMounted(async () => {
   }
 
   appsPollIntervalId = window.setInterval(async() => {
-    // Sequential await respects per-namespace page/search state and avoids
-    // firing all calls simultaneously through the k8s client rate limiter.
-    for (const ns of visibleNamespaceNames()) {
+    // Poll all known namespaces. Because we seed every namespace at mount,
+    // the first poll refreshes existing groups rather than adding new ones.
+    for (const ns of Object.keys(namespaceRows.value)) {
       await fetchNamespaceApps(
         ns,
         namespaceCurrentPages.value[ns] ?? 1,

--- a/dashboard/pkg/epinio/utils/table-formatters.ts
+++ b/dashboard/pkg/epinio/utils/table-formatters.ts
@@ -97,6 +97,11 @@ function ensureActionMenuCaptureListener() {
   }, true /* capture */);
 }
 
+// Cache action-menu elements by row ID so the same DOM node is returned on
+// every render. This preserves _isOpen state across poll-driven re-renders:
+// Lit sees the same element reference → no DOM replacement → menu stays open.
+const _actionMenuCache = new Map<string, any>();
+
 /**
  * Returns an action-menu element for a table row.
  * Transforms epinio string action names into callable functions
@@ -105,7 +110,13 @@ function ensureActionMenuCaptureListener() {
 export function makeActionMenu(row: any): HTMLElement {
   ensureActionMenuCaptureListener();
 
-  const el = document.createElement('trailhand-action-menu') as any;
+  const id = row.id ?? row.meta?.name;
+  let el = id ? _actionMenuCache.get(id) : null;
+
+  if (!el) {
+    el = document.createElement('trailhand-action-menu') as any;
+    if (id) _actionMenuCache.set(id, el);
+  }
 
   el.resource = row;
   const actions = [] as any[];


### PR DESCRIPTION
 ### PR Checklist

  - [x] Linting Test is passing
  - [x] Code is well documented
  - [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

### Summary

Related PR for the [backend](https://github.com/epinio/epinio/pull/3035)

  Fixes multiple issues with the applications list page and application model:
  - Action menu (kabob) closing on every poll cycle
  - Empty namespace groups popping in on the first poll, causing a layout jump
  - restage/restart operations providing no user feedback on progress or outcome
  - Application detail page crashing when `deployment` is null (apps in building/error state)

  ### Occurred changes and/or fixed issues

  **`table-formatters.ts`**
  - `makeActionMenu` now caches `trailhand-action-menu` elements by row ID (`_actionMenuCache` Map). The
  same DOM node is returned on every render, preserving `_isOpen` state across poll-driven re-renders.
  Previously a new element was created each call, causing Lit to replace the DOM node and reset the open
  state.
  - Added `ensureActionMenuCaptureListener`: a single document-level capture listener that closes sibling
  menus when one is opened, replacing per-element listeners that were being duplicated on every render.

  **`pages/c/_cluster/applications/index.vue`**
  - Added a `watchEffect` that seeds `namespaceRows` from the Vuex namespace store on mount. All namespace
   groups (including empty ones) are present before the first poll fires, so no groups pop in mid-session
  causing a layout jump.
  - Poll loop changed from `visibleNamespaceNames()` (all epinio namespaces) to
  `Object.keys(namespaceRows.value)` (only seeded namespaces). `watchEffect` handles discovery of new
  namespaces as `startPolling` updates the store.
  - Removed now-dead `visibleNamespaceNames()` function.

  **`models/applications.js`**
  - `restage()` and `restart()` now wrapped in try/catch with `growl/info` at start, `growl/success` on
  completion, and `growl/error` on failure. `restage()` calls `waitForStaging()` so the success
  notification fires only after staging completes.
  - `desiredInstances` setter made null-safe: guards on `this.deployment` and `this.configuration` before
  assignment.

  **`detail/applications.vue`**
  - `onMounted` now dispatches `epinio/me` to ensure permissions are fresh on the detail page.
  - Deployment section visibility changed to `v-if="value.deployment || value.image_url"` to avoid
  rendering against a null object.
  - `value.deployment.username` → `value.deployment?.username` (optional chaining).

  **`.github/workflows/release-drafter.yml`**
  - `GITHUB_TOKEN` → `secrets.PAT` to allow the release drafter to operate across repos.

  ### Technical notes summary

  The action menu fix required two parts working together: caching the element reference (so Lit sees the
  same node and doesn't replace it) and Lit's `repeat()` directive in `trailhand-table` (so the `<tr>`
  itself isn't recreated on data refresh). The `repeat()` change lives in a separate PR against
  `krumIO/trailhand-ui`.

  The namespace seeding approach uses Vue's `watchEffect` to reactively sync `namespaceRows` with the Vuex
   namespace store. This means `startPolling(['namespaces', ...])` drives discovery automatically -- no
  separate mechanism needed.

  ### Areas or cases that should be tested

  - Application list: open a kabob menu, wait for the 30-second poll to fire -- menu should stay open
  - Application list: all namespaces visible immediately on load including empty ones, no groups appearing
   after first poll
  - restage: trigger from kabob menu -- should see info toast, staging log, then success or error toast
  - restart: same notification pattern
  - Application detail: navigate to an app in `building` or `error` state (no `deployment` object) -- page
   should load without errors
  - Scale up/down on detail page while app is still initializing (`deployment` not yet set)

  ### Areas which could experience regressions

  - Application list polling and namespace group display
  - Application detail for apps without a `deployment` object
  - restage and restart flows end-to-end
  - Release drafter workflow (PAT change)