### PR TITLE
Add periodic polling on application detail page.

### DIFF
--- a/dashboard/pkg/epinio/detail/applications.vue
+++ b/dashboard/pkg/epinio/detail/applications.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, watchEffect } from 'vue';
+import { ref, computed, onMounted, onUnmounted, watchEffect } from 'vue';
 import { useStore } from 'vuex';
 import day from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -9,6 +9,7 @@ import { GitUtils } from '@shell/utils/git';
 import { isArray } from '@shell/utils/array';
 import { EPINIO_TYPES } from '../types';
 import { epinioExceptionToErrorsArray } from '../utils/errors';
+import { startPolling, stopPolling } from '../utils/polling';
 import Tabs from '../components/application/Tabs.vue';
 import Banner from '@components/Banner/Banner.vue';
 import { makeStateTag, makeActionMenu, makeCommitShaCell, makeCommitAuthorCell, overrideTableRows } from '../utils/table-formatters';
@@ -331,6 +332,7 @@ onMounted(async () => {
   await store.dispatch('epinio/me'); //Need to fetch fresh rights for scaling
   await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.SERVICE_INSTANCE });
   await store.dispatch('epinio/findAll', { type: EPINIO_TYPES.CONFIGURATION });
+  startPolling([EPINIO_TYPES.APP, EPINIO_TYPES.SERVICE_INSTANCE, EPINIO_TYPES.CONFIGURATION], store);
 
   if (props.value.appSource.git) {
     await fetchRepoDetails();
@@ -339,6 +341,10 @@ onMounted(async () => {
       { id: 'gitCommits', label: t('epinio.applications.detail.tables.gitCommits'), completed: false, valid: true, disabled: false }
     );
   }
+});
+
+onUnmounted(() => {
+  stopPolling([EPINIO_TYPES.APP, EPINIO_TYPES.SERVICE_INSTANCE, EPINIO_TYPES.CONFIGURATION]);
 });
 
 async function updateInstances(newInstances: number) {


### PR DESCRIPTION
Start polling when the application detail view mounts and stop polling on unmount so app-related data refreshes automatically without manual reload.

### PR Checklist
- [x] Linting Test is passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
The Application Detail page did not refresh on its own; users had to reload the browser to see updated status, instance counts, bound services, or configurations. This PR wires up the existing polling utility so the detail view stays in sync while it is open, and stops polling when the user navigates away.

### Occurred changes and/or fixed issues
dashboard/pkg/epinio/detail/applications.vue
Import startPolling and stopPolling from ../utils/polling.
Call startPolling in onMounted for applications, service instances, and configurations (after the initial findAll fetches).
Call stopPolling in onUnmounted for the same resource types.
No backend changes; the Epinio API and store findAll with force: true / _MERGE already supported refresh.
No docs PR required (UI-only behavior change, consistent with other list/detail pages that already poll).

### Technical notes summary
Reuses dashboard/pkg/epinio/utils/polling.ts, which wraps PollerSequential and polls every 30 seconds.
Polled types: EPINIO_TYPES.APP, EPINIO_TYPES.SERVICE_INSTANCE, EPINIO_TYPES.CONFIGURATION (applications, services, configurations).
Each poll dispatches epinio/findAll with { force: true, load: _MERGE }, merging fresh data into the store without a full page reload.
Polling is scoped to the detail view lifecycle (onMounted / onUnmounted), matching the pattern used on the Applications list page, Namespaces list, Services list, and Catalog Service detail page.
The Applications list page already polled applications and namespaces; this change only adds polling to the detail page, which previously did not poll.
### Areas or cases that should be tested
Browser used for local testing: (Chrome)

Polling starts on detail page

Open Epinio UI → Applications → select an app to open its detail view.
In DevTools → Network, filter by api/v1.
Confirm periodic (~30s) requests to applications, services, and configurations.

### Areas which could experience regressions
Instance scaling UI — polling merges app data while the user may be scaling; verify scaling controls and debounced updates are not disrupted by incoming poll data.
Services / configurations tables — bound resources are derived from polled store data; verify rows stay correct when services or configs change externally

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
