### PR TITLE
Feat/epinio action menu notifications

### DIFF
--- a/dashboard/pkg/epinio/components/application/AppDeleteModal.vue
+++ b/dashboard/pkg/epinio/components/application/AppDeleteModal.vue
@@ -43,15 +43,15 @@ async function onSubmitDelete() {
     emit('deleted', appToDelete.value);
     closeDelete();
     store.dispatch('growl/success', {
-      title: 'Application Deleted',
-      message: `Your application ${appName} has been successfully deleted.`,
+      title:   t('epinio.growl.application.delete.success.title'),
+      message: t('epinio.growl.application.delete.success.message', { name: appName }),
     });
     store.dispatch('epinio/findAll', { type: EPINIO_TYPES.APP, opt: { force: true } });
   } catch (e: any) {
     errors.value = epinioExceptionToErrorsArray(e);
     store.dispatch('growl/error', {
-      title: 'Application Deletion Failed',
-      message: `Failed to delete application ${appName}. Please try again. Error details: ${e instanceof Error ? e.message : String(e)}`,
+      title:   t('epinio.growl.application.delete.error.title'),
+      message: t('epinio.growl.application.delete.error.message', { name: appName, error: e instanceof Error ? e.message : String(e) }),
     });
   } finally {
     deleting.value = false;

--- a/dashboard/pkg/epinio/components/application/AppProgress.vue
+++ b/dashboard/pkg/epinio/components/application/AppProgress.vue
@@ -104,11 +104,15 @@ const create = async () => {
     } catch (err) {
       running.value = false;
       console.error(err);
+      const errDetails = err instanceof Error ? err.message : String(err);
+
       store.dispatch('growl/error', {
-        title: props.mode === 'edit' ? 'Application Update Failed' : 'Application Deployment Failed',
+        title: props.mode === 'edit'
+          ? t('epinio.growl.application.update.error.title')
+          : t('epinio.growl.application.deploy.error.title'),
         message: props.mode === 'edit'
-          ? `Your application ${props.application.meta.name} failed to update. Please try again. Error details: ${err instanceof Error ? err.message : String(err)}`
-          : `Your application ${props.application.meta.name} failed to deploy. Please try again. Error details: ${err instanceof Error ? err.message : String(err)}`,
+          ? t('epinio.growl.application.update.error.message', { name: props.application.meta.name, error: errDetails })
+          : t('epinio.growl.application.deploy.error.message', { name: props.application.meta.name, error: errDetails }),
       });
       await fetchApp();
       return;
@@ -116,10 +120,12 @@ const create = async () => {
   }
   
   store.dispatch('growl/success', {
-    title: props.mode === 'edit' ? 'Application Updates Deployed' : 'Application Deployed',
+    title: props.mode === 'edit'
+      ? t('epinio.growl.application.update.success.title')
+      : t('epinio.growl.application.deploy.success.title'),
     message: props.mode === 'edit'
-      ? `Your application ${props.application.meta.name} has been successfully updated.`
-      : `Your application ${props.application.meta.name} has been successfully deployed.`,
+      ? t('epinio.growl.application.update.success.message', { name: props.application.meta.name })
+      : t('epinio.growl.application.deploy.success.message', { name: props.application.meta.name }),
   });
   await fetchApp();
   running.value = false;

--- a/dashboard/pkg/epinio/components/configuration/ConfigurationDeleteModal.vue
+++ b/dashboard/pkg/epinio/components/configuration/ConfigurationDeleteModal.vue
@@ -53,16 +53,16 @@ async function onSubmitDelete() {
     await cfg.remove();
     closeDelete();
     store.dispatch('growl/success', {
-      title: 'Configuration Deleted',
-      message: `Your configuration ${ configName } has been successfully deleted.`,
+      title:   t('epinio.growl.configuration.delete.success.title'),
+      message: t('epinio.growl.configuration.delete.success.message', { name: configName }),
     });
     store.dispatch('epinio/findAll', { type: EPINIO_TYPES.CONFIGURATION, opt: { force: true } });
     store.dispatch('epinio/findAll', { type: EPINIO_TYPES.APP, opt: { force: true } });
   } catch (e: any) {
     errors.value = epinioExceptionToErrorsArray(e);
     store.dispatch('growl/error', {
-      title: 'Configuration Deletion Failed',
-      message: `Failed to delete configuration ${ configToDelete.value?.meta?.name }. Please try again.`,
+      title:   t('epinio.growl.configuration.delete.error.title'),
+      message: t('epinio.growl.configuration.delete.error.message', { name: configToDelete.value?.meta?.name }),
     });
   } finally {
     deleting.value = false;

--- a/dashboard/pkg/epinio/components/configuration/ConfigurationDeleteModal.vue
+++ b/dashboard/pkg/epinio/components/configuration/ConfigurationDeleteModal.vue
@@ -52,10 +52,18 @@ async function onSubmitDelete() {
 
     await cfg.remove();
     closeDelete();
+    store.dispatch('growl/success', {
+      title: 'Configuration Deleted',
+      message: `Your configuration ${ configName } has been successfully deleted.`,
+    });
     store.dispatch('epinio/findAll', { type: EPINIO_TYPES.CONFIGURATION, opt: { force: true } });
     store.dispatch('epinio/findAll', { type: EPINIO_TYPES.APP, opt: { force: true } });
   } catch (e: any) {
     errors.value = epinioExceptionToErrorsArray(e);
+    store.dispatch('growl/error', {
+      title: 'Configuration Deletion Failed',
+      message: `Failed to delete configuration ${ configToDelete.value?.meta?.name }. Please try again.`,
+    });
   } finally {
     deleting.value = false;
   }

--- a/dashboard/pkg/epinio/components/configuration/ConfigurationModal.vue
+++ b/dashboard/pkg/epinio/components/configuration/ConfigurationModal.vue
@@ -282,6 +282,11 @@ async function onSubmit() {
 
       closeModal();
 
+      store.dispatch('growl/success', {
+        title: 'Configuration Created',
+        message: `Your configuration ${ capturedName } has been successfully created.`,
+      });
+
       cfg.forceFetch().catch(() => {});
 
       if (capturedSelectedApps.length) {
@@ -308,6 +313,11 @@ async function onSubmit() {
       }
 
       closeModal();
+
+      store.dispatch('growl/success', {
+        title: 'Configuration Updated',
+        message: `Your configuration ${ capturedName } has been successfully updated.`,
+      });
 
       // Determine which apps were newly bound or unbound, and update accordingly
       const newBindApps = capturedSelectedApps.filter(a => !capturedInitialApps.includes(a));
@@ -336,6 +346,10 @@ async function onSubmit() {
     }
   } catch (err: any) {
     errors.value = epinioExceptionToErrorsArray(err);
+    store.dispatch('growl/error', {
+      title: isEdit.value ? 'Configuration Update Failed' : 'Configuration Creation Failed',
+      message: `Something went wrong. Please try again or contact your system admin to investigate the issue.`,
+    });
   } finally {
     saving.value = false;
   }

--- a/dashboard/pkg/epinio/components/configuration/ConfigurationModal.vue
+++ b/dashboard/pkg/epinio/components/configuration/ConfigurationModal.vue
@@ -10,6 +10,7 @@ import isEqual from 'lodash/isEqual';
 import sortBy from 'lodash/sortBy';
 
 const store = useStore() as any;
+const t = store.getters['i18n/t'];
 
 const showModal = ref(false);
 const modalMode = ref<'view' | 'edit' | 'create'>('view');
@@ -283,8 +284,8 @@ async function onSubmit() {
       closeModal();
 
       store.dispatch('growl/success', {
-        title: 'Configuration Created',
-        message: `Your configuration ${ capturedName } has been successfully created.`,
+        title:   t('epinio.growl.configuration.create.success.title'),
+        message: t('epinio.growl.configuration.create.success.message', { name: capturedName }),
       });
 
       cfg.forceFetch().catch(() => {});
@@ -315,8 +316,8 @@ async function onSubmit() {
       closeModal();
 
       store.dispatch('growl/success', {
-        title: 'Configuration Updated',
-        message: `Your configuration ${ capturedName } has been successfully updated.`,
+        title:   t('epinio.growl.configuration.update.success.title'),
+        message: t('epinio.growl.configuration.update.success.message', { name: capturedName }),
       });
 
       // Determine which apps were newly bound or unbound, and update accordingly
@@ -347,8 +348,10 @@ async function onSubmit() {
   } catch (err: any) {
     errors.value = epinioExceptionToErrorsArray(err);
     store.dispatch('growl/error', {
-      title: isEdit.value ? 'Configuration Update Failed' : 'Configuration Creation Failed',
-      message: `Something went wrong. Please try again or contact your system admin to investigate the issue.`,
+      title: isEdit.value
+        ? t('epinio.growl.configuration.save.error.updateTitle')
+        : t('epinio.growl.configuration.save.error.createTitle'),
+      message: t('epinio.growl.configuration.save.error.message'),
     });
   } finally {
     saving.value = false;

--- a/dashboard/pkg/epinio/components/service/ServiceDeleteModal.vue
+++ b/dashboard/pkg/epinio/components/service/ServiceDeleteModal.vue
@@ -27,15 +27,25 @@ async function onSubmitDelete() {
 if (!serviceToDelete.value) {
     return;
 }
+const serviceName = serviceToDelete.value.meta.name;
+
 try {
     deletingService.value = true;
     await serviceToDelete.value.remove();
     closeDelete();
+    store.dispatch('growl/success', {
+      title: 'Service Instance Deleted',
+      message: `Your service instance ${ serviceName } has been successfully deleted.`,
+    });
     store.dispatch('epinio/findAll', { type: EPINIO_TYPES.SERVICE_INSTANCE, opt: { force: true } });
-    store.dispatch('findAll', { type: 'applications', opt: { force: true } });
+    store.dispatch('epinio/findAll', { type: EPINIO_TYPES.APP, opt: { force: true } });
 } catch(e) {
     errors.value = [];
     errors.value = epinioExceptionToErrorsArray(e).map(JSON.stringify);
+    store.dispatch('growl/error', {
+      title: 'Service Instance Deletion Failed',
+      message: `Failed to delete service instance ${ serviceName }. Please try again.`,
+    });
 } finally {
     deletingService.value = false;
 }

--- a/dashboard/pkg/epinio/components/service/ServiceDeleteModal.vue
+++ b/dashboard/pkg/epinio/components/service/ServiceDeleteModal.vue
@@ -12,6 +12,7 @@ const errors = ref<Array<string>>([]);
 const deletingService = ref<boolean>(false);
 
 const store = useStore();
+const t = store.getters['i18n/t'];
 
 function openDelete(row: EpinioServiceModel) {
   serviceToDelete.value = row;
@@ -34,8 +35,8 @@ try {
     await serviceToDelete.value.remove();
     closeDelete();
     store.dispatch('growl/success', {
-      title: 'Service Instance Deleted',
-      message: `Your service instance ${ serviceName } has been successfully deleted.`,
+      title:   t('epinio.growl.serviceInstance.delete.success.title'),
+      message: t('epinio.growl.serviceInstance.delete.success.message', { name: serviceName }),
     });
     store.dispatch('epinio/findAll', { type: EPINIO_TYPES.SERVICE_INSTANCE, opt: { force: true } });
     store.dispatch('epinio/findAll', { type: EPINIO_TYPES.APP, opt: { force: true } });
@@ -43,8 +44,8 @@ try {
     errors.value = [];
     errors.value = epinioExceptionToErrorsArray(e).map(JSON.stringify);
     store.dispatch('growl/error', {
-      title: 'Service Instance Deletion Failed',
-      message: `Failed to delete service instance ${ serviceName }. Please try again.`,
+      title:   t('epinio.growl.serviceInstance.delete.error.title'),
+      message: t('epinio.growl.serviceInstance.delete.error.message', { name: serviceName }),
     });
 } finally {
     deletingService.value = false;

--- a/dashboard/pkg/epinio/components/service/ServiceInstanceModal.vue
+++ b/dashboard/pkg/epinio/components/service/ServiceInstanceModal.vue
@@ -282,6 +282,11 @@ async function onSubmit() {
 
       closeModal();
 
+      store.dispatch('growl/success', {
+        title: 'Service Instance Created',
+        message: `Your service instance ${ capturedName } has been successfully created.`,
+      });
+
       // Show the new item quickly, then bind apps and refresh again once done
       svc.forceFetch().catch(() => {});
       if (capturedSelectedApps.length) {
@@ -307,8 +312,14 @@ async function onSubmit() {
       const bindApps = selectedApps.value;
       const unbindApps = initialBoundApps.value.filter(a => !bindApps.includes(a));
       const newBindApps = bindApps.filter(a => !initialBoundApps.value.includes(a));
+      const serviceName = svc.meta?.name;
 
       closeModal();
+
+      store.dispatch('growl/success', {
+        title: 'Service Instance Updated',
+        message: `Your service instance ${ serviceName } has been successfully updated.`,
+      });
 
       // Bind/unbind and refresh in the background
       Promise.all([
@@ -319,6 +330,10 @@ async function onSubmit() {
     }
   } catch (err: any) {
     errors.value = epinioExceptionToErrorsArray(err);
+    store.dispatch('growl/error', {
+      title: isEdit.value ? 'Service Instance Update Failed' : 'Service Instance Creation Failed',
+      message: `Something went wrong. Please try again or contact your system admin to investigate the issue.`,
+    });
   } finally {
     saving.value = false;
   }

--- a/dashboard/pkg/epinio/components/service/ServiceInstanceModal.vue
+++ b/dashboard/pkg/epinio/components/service/ServiceInstanceModal.vue
@@ -283,8 +283,8 @@ async function onSubmit() {
       closeModal();
 
       store.dispatch('growl/success', {
-        title: 'Service Instance Created',
-        message: `Your service instance ${ capturedName } has been successfully created.`,
+        title:   t('epinio.growl.serviceInstance.create.success.title'),
+        message: t('epinio.growl.serviceInstance.create.success.message', { name: capturedName }),
       });
 
       // Show the new item quickly, then bind apps and refresh again once done
@@ -317,8 +317,8 @@ async function onSubmit() {
       closeModal();
 
       store.dispatch('growl/success', {
-        title: 'Service Instance Updated',
-        message: `Your service instance ${ serviceName } has been successfully updated.`,
+        title:   t('epinio.growl.serviceInstance.update.success.title'),
+        message: t('epinio.growl.serviceInstance.update.success.message', { name: serviceName }),
       });
 
       // Bind/unbind and refresh in the background
@@ -331,8 +331,10 @@ async function onSubmit() {
   } catch (err: any) {
     errors.value = epinioExceptionToErrorsArray(err);
     store.dispatch('growl/error', {
-      title: isEdit.value ? 'Service Instance Update Failed' : 'Service Instance Creation Failed',
-      message: `Something went wrong. Please try again or contact your system admin to investigate the issue.`,
+      title: isEdit.value
+        ? t('epinio.growl.serviceInstance.save.error.updateTitle')
+        : t('epinio.growl.serviceInstance.save.error.createTitle'),
+      message: t('epinio.growl.serviceInstance.save.error.message'),
     });
   } finally {
     saving.value = false;

--- a/dashboard/pkg/epinio/dialog/ExportAppModal.vue
+++ b/dashboard/pkg/epinio/dialog/ExportAppModal.vue
@@ -101,8 +101,8 @@ const exportApplicationManifest = async () => {
     }
 
     store.dispatch('growl/success', {
-      title: 'Application Exported!',
-      message: `${ resource.meta.name } has been exported successfully.`,
+      title:   t('epinio.growl.application.export.success.title'),
+      message: t('epinio.growl.application.export.success.message', { name: resource.meta.name }),
     });
     exportSucceeded = true;
   } catch (error) {
@@ -111,8 +111,8 @@ const exportApplicationManifest = async () => {
     errors.value.push(message);
     disableDownload();
     store.dispatch('growl/error', {
-      title: 'Something Went Wrong Exporting!',
-      message: `Can't export the application. Please try again or contact your system admin to investigate the issue.`,
+      title:   t('epinio.growl.application.export.error.title'),
+      message: t('epinio.growl.application.export.error.message'),
     });
   } finally {
     exporting.value = false;

--- a/dashboard/pkg/epinio/dialog/ExportAppModal.vue
+++ b/dashboard/pkg/epinio/dialog/ExportAppModal.vue
@@ -41,6 +41,7 @@ const exportApplicationManifest = async () => {
   exporting.value = true;
   enableDownload();
   const resource = resources.value[0];
+  let exportSucceeded = false;
 
   try {
     const chartZip = async(files) => {
@@ -103,17 +104,21 @@ const exportApplicationManifest = async () => {
       title: 'Application Exported!',
       message: `${ resource.meta.name } has been exported successfully.`,
     });
+    exportSucceeded = true;
   } catch (error) {
     const message = error.message ?? 'Error exporting application';
 
     errors.value.push(message);
+    disableDownload();
     store.dispatch('growl/error', {
       title: 'Something Went Wrong Exporting!',
       message: `Can't export the application. Please try again or contact your system admin to investigate the issue.`,
     });
   } finally {
     exporting.value = false;
-    closeExport();  
+    if (exportSucceeded) {
+      closeExport();
+    }
   }
 
 

--- a/dashboard/pkg/epinio/dialog/ExportAppModal.vue
+++ b/dashboard/pkg/epinio/dialog/ExportAppModal.vue
@@ -80,27 +80,37 @@ const exportApplicationManifest = async () => {
           'application/zip',
         );
         await delayBeforeClose(1500);
-        return;
+      } else {
+        // Fallback: fetch three parts and zip in browser (slower, especially in Rancher extension)
+        const partsData = await zipParts.value.reduce(async(acc, part) => ({
+          ...await acc,
+          [part]: await fetchPart(resource, part),
+        }), Promise.resolve({}));
+
+        if (Object.values(partsData).some((part) => !part)) {
+          throw new Error('One or more export parts could not be downloaded');
+        }
+
+        toggleStep('zip');
+
+        await chartZip(partsData);
+
+        await delayBeforeClose(1500);
       }
-
-      // Fallback: fetch three parts and zip in browser (slower, especially in Rancher extension)
-      const partsData = await zipParts.value.reduce(async(acc, part) => ({
-        ...await acc,
-        [part]: await fetchPart(resource, part),
-      }), Promise.resolve({}));
-
-      if (Object.values(partsData).some((part) => !part)) {
-        return;
-      }
-
-      toggleStep('zip');
-
-      await chartZip(partsData);
-
-      await delayBeforeClose(1500);
     }
+
+    store.dispatch('growl/success', {
+      title: 'Application Exported!',
+      message: `${ resource.meta.name } has been exported successfully.`,
+    });
   } catch (error) {
-    errors.value.push(error.message ?? 'Error exporting application');
+    const message = error.message ?? 'Error exporting application';
+
+    errors.value.push(message);
+    store.dispatch('growl/error', {
+      title: 'Something Went Wrong Exporting!',
+      message: `Can't export the application. Please try again or contact your system admin to investigate the issue.`,
+    });
   } finally {
     exporting.value = false;
     closeExport();  

--- a/dashboard/pkg/epinio/l10n/en-us.yaml
+++ b/dashboard/pkg/epinio/l10n/en-us.yaml
@@ -419,6 +419,138 @@ epinio:
     title: Unsaved Changes
     message: You have unsaved changes. Are you sure you want to leave this page?
     discard: Discard Changes
+  growl:
+    application:
+      deploy:
+        success:
+          title: Application Deployed
+          message: 'Your application { name } has been successfully deployed.'
+        error:
+          title: Application Deployment Failed
+          message: 'Your application { name } failed to deploy. Please try again. Error details: { error }'
+      update:
+        success:
+          title: Application Updates Deployed
+          message: 'Your application { name } has been successfully updated.'
+        error:
+          title: Application Update Failed
+          message: 'Your application { name } failed to update. Please try again. Error details: { error }'
+      delete:
+        success:
+          title: Application Deleted
+          message: 'Your application { name } has been successfully deleted.'
+        error:
+          title: Application Deletion Failed
+          message: 'Failed to delete application { name }. Please try again. Error details: { error }'
+      restage:
+        info:
+          title: Attempting to Rebuild Application!
+          message: This may take a few moments, a window will open with live logs soon.
+        success:
+          title: Application Rebuilt Successfully!
+          message: '{ name } has been rebuilt successfully.'
+        error:
+          title: Something Went Wrong Rebuilding!
+          message: This error occurs when there are missing resources in the cluster, contact your system admin to investigate the issue.
+      restart:
+        info:
+          title: Attempting to Restart Application!
+          message: This can take a few moments, we'll let you know once it's ready.
+        success:
+          title: Application Restarted!
+          message: '{ name } has been restarted successfully.'
+        error:
+          title: Something Went Wrong Restarting!
+          message: Can't restart the application, the image may be missing, reach out to your system admin to investigate the issue.
+      deployment:
+        error:
+          title: Something Went Wrong Opening Deployment!
+          message: Can't view the deployment in the cluster. Please try again or contact your system admin to investigate the issue.
+      shell:
+        error:
+          title: Something Went Wrong Opening App Shell!
+          message: Can't open the application shell. The application may not have running instances yet.
+      appLogs:
+        error:
+          title: Something Went Wrong Opening App Logs!
+          message: Can't open application logs. Please try again or contact your system admin to investigate the issue.
+      buildLogs:
+        error:
+          title: Something Went Wrong Opening Build Logs!
+          message: Can't open build logs. Please try again or contact your system admin to investigate the issue.
+        noInfo:
+          title: Something Went Wrong Opening Build Logs!
+          message: 'Can''t show build logs for { name }, no build information is available.'
+      manifest:
+        error:
+          title: Something Went Wrong Downloading Manifest!
+          message: Can't download the application manifest. Please try again or contact your system admin to investigate the issue.
+      export:
+        success:
+          title: Application Exported!
+          message: '{ name } has been exported successfully.'
+        error:
+          title: Something Went Wrong Exporting!
+          message: Can't export the application. Please try again or contact your system admin to investigate the issue.
+    configuration:
+      create:
+        success:
+          title: Configuration Created
+          message: 'Your configuration { name } has been successfully created.'
+      update:
+        success:
+          title: Configuration Updated
+          message: 'Your configuration { name } has been successfully updated.'
+      save:
+        error:
+          createTitle: Configuration Creation Failed
+          updateTitle: Configuration Update Failed
+          message: Something went wrong. Please try again or contact your system admin to investigate the issue.
+      delete:
+        success:
+          title: Configuration Deleted
+          message: 'Your configuration { name } has been successfully deleted.'
+        error:
+          title: Configuration Deletion Failed
+          message: 'Failed to delete configuration { name }. Please try again or contact your system admin to investigate the issue.'
+    service:
+      bind:
+        error:
+          title: Something Went Wrong Binding the Service
+          message: The service most likely wasn't ready yet. Please wait a moment and try again. If the problem persists, please contact support.
+      unbind:
+        error:
+          title: Something Went Wrong Unbinding the Service
+          message: Please wait a moment and try again. Please try again or contact your system admin to investigate the issue.
+    serviceInstance:
+      create:
+        success:
+          title: Service Instance Created
+          message: 'Your service instance { name } has been successfully created.'
+      update:
+        success:
+          title: Service Instance Updated
+          message: 'Your service instance { name } has been successfully updated.'
+      save:
+        error:
+          createTitle: Service Instance Creation Failed
+          updateTitle: Service Instance Update Failed
+          message: Something went wrong. Please try again or contact your system admin to investigate the issue.
+      delete:
+        success:
+          title: Service Instance Deleted
+          message: 'Your service instance { name } has been successfully deleted.'
+        error:
+          title: Service Instance Deletion Failed
+          message: 'Failed to delete service instance { name }. Please try again or contact your system admin to investigate the issue.'
+    auth:
+      logout:
+        success:
+          title: Logged Out Successfully!
+          message: You have been logged out of Epinio.
+        error:
+          title: Something Went Wrong Logging Out!
+          message: Can't log out. Please try again or contact your system admin to investigate the issue.
 model:
   authConfig:
     provider:

--- a/dashboard/pkg/epinio/list/services.vue
+++ b/dashboard/pkg/epinio/list/services.vue
@@ -139,11 +139,11 @@ watchEffect(() => {
 
 onMounted(() => {
   store.dispatch('epinio/me');
+  store.dispatch('epinio/findAll', { type: EPINIO_TYPES.APP });
   store.dispatch('epinio/findAll', { type: EPINIO_TYPES.SERVICE_INSTANCE });
   store.dispatch('epinio/findAll', { type: EPINIO_TYPES.NAMESPACE });
   store.dispatch('epinio/findAll', { type: EPINIO_TYPES.CATALOG_SERVICE });
-  store.dispatch('epinio/findAll', { type: EPINIO_TYPES.APP });
-  startPolling(['services'], store);
+  startPolling(['services', 'applications'], store);
 
   const query = store.$router.currentRoute._value.query;
 
@@ -153,7 +153,7 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-  stopPolling(['services']);
+  stopPolling(['services', 'applications']);
 });
 
 const handleNavigate = (event: CustomEvent) => {

--- a/dashboard/pkg/epinio/models/application-instance.js
+++ b/dashboard/pkg/epinio/models/application-instance.js
@@ -38,17 +38,25 @@ export default class ApplicationInstanceResource extends Resource {
   }
 
   showAppShell() {
-    this.$dispatch('wm/open', {
-      id:        `epinio-${ this.application.id }-app-shell`,
-      label:     `${ this.application.meta.name } - App Shell`,
-      product:   EPINIO_PRODUCT_NAME,
-      icon:      'chevron-right',
-      component: 'ApplicationShell',
-      attrs:     {
-        application:     this.application,
-        endpoint:        this.application.linkFor('shell'),
-        initialInstance: this.name,
-      }
-    }, { root: true });
+    try {
+      this.$dispatch('wm/open', {
+        id:        `epinio-${ this.application.id }-app-shell`,
+        label:     `${ this.application.meta.name } - App Shell`,
+        product:   EPINIO_PRODUCT_NAME,
+        icon:      'chevron-right',
+        component: 'ApplicationShell',
+        attrs:     {
+          application:     this.application,
+          endpoint:        this.application.linkFor('shell'),
+          initialInstance: this.name,
+        }
+      }, { root: true });
+    } catch (e) {
+      console.log(e);
+      this.$dispatch('growl/error', {
+        title: 'Something Went Wrong Opening App Shell!',
+        message: `Can't open the application shell. The application may not have running instances yet.`,
+      }, { root: true });
+    }
   }
 }

--- a/dashboard/pkg/epinio/models/application-instance.js
+++ b/dashboard/pkg/epinio/models/application-instance.js
@@ -54,8 +54,8 @@ export default class ApplicationInstanceResource extends Resource {
     } catch (e) {
       console.log(e);
       this.$dispatch('growl/error', {
-        title: 'Something Went Wrong Opening App Shell!',
-        message: `Can't open the application shell. The application may not have running instances yet.`,
+        title:   this.t('epinio.growl.application.shell.error.title'),
+        message: this.t('epinio.growl.application.shell.error.message'),
       }, { root: true });
     }
   }

--- a/dashboard/pkg/epinio/models/applications.js
+++ b/dashboard/pkg/epinio/models/applications.js
@@ -656,7 +656,12 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
         } else {
           this.currentRouter().push(deploymentList);
         }
-      }).catch(() => {
+      }).catch((e) => {
+        console.log(e);
+        this.$dispatch('growl/error', {
+          title: 'Something Went Wrong Opening Deployment!',
+          message: `Can't view the deployment in the cluster. Please try again or contact your system admin to investigate the issue.`,
+        }, { root: true });
         this.currentRouter().push(deploymentList);
       });
   }
@@ -859,57 +864,92 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
   }
 
   showAppShell() {
-    this.$dispatch('wm/open', {
-      id:        this.appShellId,
-      label:     `${ this.meta.name } - App Shell`,
-      product:   EPINIO_PRODUCT_NAME,
-      icon:      'chevron-right',
-      component: 'ApplicationShell',
-      attrs:     {
-        application:     this,
-        endpoint:        this.linkFor('shell'),
-        initialInstance: this.instances[0].id
+    try {
+      const initialInstance = this.instances?.[0]?.id;
+
+      if (!initialInstance) {
+        throw new Error('No running instances available');
       }
-    }, { root: true });
+
+      this.$dispatch('wm/open', {
+        id:        this.appShellId,
+        label:     `${ this.meta.name } - App Shell`,
+        product:   EPINIO_PRODUCT_NAME,
+        icon:      'chevron-right',
+        component: 'ApplicationShell',
+        attrs:     {
+          application:     this,
+          endpoint:        this.linkFor('shell'),
+          initialInstance,
+        }
+      }, { root: true });
+    } catch (e) {
+      console.log(e);
+      this.$dispatch('growl/error', {
+        title: 'Something Went Wrong Opening App Shell!',
+        message: `Can't open the application shell. The application may not have running instances yet.`,
+      }, { root: true });
+    }
   }
 
   showAppLog() {
-    this.$dispatch('wm/open', {
-      id:        this.appLogId,
-      label:     `${ this.meta.name } - App Logs`,
-      product:   EPINIO_PRODUCT_NAME,
-      icon:      'file',
-      component: 'ApplicationLogs',
-      attrs:     {
-        application: this,
-        endpoint:    this.linkFor('logs')
-      }
-    }, { root: true });
+    try {
+      this.$dispatch('wm/open', {
+        id:        this.appLogId,
+        label:     `${ this.meta.name } - App Logs`,
+        product:   EPINIO_PRODUCT_NAME,
+        icon:      'file',
+        component: 'ApplicationLogs',
+        attrs:     {
+          application: this,
+          endpoint:    this.linkFor('logs')
+        }
+      }, { root: true });
+    } catch (e) {
+      console.log(e);
+      this.$dispatch('growl/error', {
+        title: 'Something Went Wrong Opening App Logs!',
+        message: `Can't open application logs. Please try again or contact your system admin to investigate the issue.`,
+      }, { root: true });
+    }
   }
 
   showStagingLog(stageId = this.stage_id) {
     if (!stageId) {
-      console.warn('Unable to show staging logs, no stage id');
+      this.$dispatch('growl/error', {
+        title: 'Something Went Wrong Opening Build Logs!',
+        message: `Can't show build logs for ${ this.meta.name }, no build information is available.`,
+      }, { root: true });
+
+      return;
     }
 
-    // /namespaces/:namespace/staging/:stage_id/logs
-    let endpoint = `${ this.getUrl(this.meta?.namespace, stageId) }/logs`;
+    try {
+      // /namespaces/:namespace/staging/:stage_id/logs
+      let endpoint = `${ this.getUrl(this.meta?.namespace, stageId) }/logs`;
 
-    endpoint = endpoint.replace('/api/v1', '/wapi/v1');
-    endpoint = endpoint.replace('/applications', '/staging');
+      endpoint = endpoint.replace('/api/v1', '/wapi/v1');
+      endpoint = endpoint.replace('/applications', '/staging');
 
-    this.$dispatch('wm/open', {
-      id:        `${ this.stagingLog }${ stageId }`,
-      label:     `${ this.meta.name } - Build - ${ stageId }`,
-      product:   EPINIO_PRODUCT_NAME,
-      icon:      'file',
-      component: 'ApplicationLogs',
-      attrs:     {
-        application: this,
-        endpoint,
-        ansiToHtml:  true
-      }
-    }, { root: true });
+      this.$dispatch('wm/open', {
+        id:        `${ this.stagingLog }${ stageId }`,
+        label:     `${ this.meta.name } - Build - ${ stageId }`,
+        product:   EPINIO_PRODUCT_NAME,
+        icon:      'file',
+        component: 'ApplicationLogs',
+        attrs:     {
+          application: this,
+          endpoint,
+          ansiToHtml:  true
+        }
+      }, { root: true });
+    } catch (e) {
+      console.log(e);
+      this.$dispatch('growl/error', {
+        title: 'Something Went Wrong Opening Build Logs!',
+        message: `Can't open build logs. Please try again or contact your system admin to investigate the issue.`,
+      }, { root: true });
+    }
   }
 
   closeWindows() {
@@ -1373,14 +1413,21 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
   }
 
   async createManifest() {
-    const date = new Date().toISOString().split('.')[0];
-    const fileName = `${ this.metadata.namespace }-${ this.nameDisplay }-${ date }.yaml`;
+    try {
+      const date = new Date().toISOString().split('.')[0];
+      const fileName = `${ this.metadata.namespace }-${ this.nameDisplay }-${ date }.yaml`;
 
-    const manifest = await this.fetchPart('manifest');
+      const manifest = await this.fetchPart('manifest');
 
-    downloadFile(fileName, manifest, 'application/yaml').catch((e) => {
-      console.error('Failed to download manifest: ', e);
-    });
+      await downloadFile(fileName, manifest, 'application/yaml');
+    } catch (e) {
+      console.log(e);
+      this.$dispatch('growl/error', {
+        title: 'Something Went Wrong Downloading Manifest!',
+        message: `Can't download the application manifest. Please try again or contact your system admin to investigate the issue.`,
+      }, { root: true });
+      throw e;
+    }
   }
 
   async updateConfigurations(initialValues = [], currentValues = this.configuration.configurations) {

--- a/dashboard/pkg/epinio/models/applications.js
+++ b/dashboard/pkg/epinio/models/applications.js
@@ -659,8 +659,8 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
       }).catch((e) => {
         console.log(e);
         this.$dispatch('growl/error', {
-          title: 'Something Went Wrong Opening Deployment!',
-          message: `Can't view the deployment in the cluster. Please try again or contact your system admin to investigate the issue.`,
+          title:   this.t('epinio.growl.application.deployment.error.title'),
+          message: this.t('epinio.growl.application.deployment.error.message'),
         }, { root: true });
         this.currentRouter().push(deploymentList);
       });
@@ -796,9 +796,8 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
 
   async restage() {
     this.$dispatch('growl/info', {
-      title: 'Attempting to Rebuild Application!',
-      message: `This may take a few moments, a window will open with live logs
-      soon.`,
+      title:   this.t('epinio.growl.application.restage.info.title'),
+      message: this.t('epinio.growl.application.restage.info.message'),
     }, { root: true });
     try {
       const { stage } = await this.stage();
@@ -806,15 +805,14 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
       this.showStagingLog(stage.id);
       await this.waitForStaging(stage.id);
       this.$dispatch('growl/success', {
-        title:   'Application Rebuilt Successfully!',
-        message: `${ this.meta.name } has been rebuilt successfully.`,
+        title:   this.t('epinio.growl.application.restage.success.title'),
+        message: this.t('epinio.growl.application.restage.success.message', { name: this.meta.name }),
       }, { root: true });
     } catch (e) {
       console.log(e);
       this.$dispatch('growl/error', {
-        title: 'Something Went Wrong Rebuilding!',
-        message: `This error occurs when there are missing resources in the
-        cluster, contact your system admin to investigate the issue.`,
+        title:   this.t('epinio.growl.application.restage.error.title'),
+        message: this.t('epinio.growl.application.restage.error.message'),
       }, { root: true });
     }
   }
@@ -886,8 +884,8 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
     } catch (e) {
       console.log(e);
       this.$dispatch('growl/error', {
-        title: 'Something Went Wrong Opening App Shell!',
-        message: `Can't open the application shell. The application may not have running instances yet.`,
+        title:   this.t('epinio.growl.application.shell.error.title'),
+        message: this.t('epinio.growl.application.shell.error.message'),
       }, { root: true });
     }
   }
@@ -908,8 +906,8 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
     } catch (e) {
       console.log(e);
       this.$dispatch('growl/error', {
-        title: 'Something Went Wrong Opening App Logs!',
-        message: `Can't open application logs. Please try again or contact your system admin to investigate the issue.`,
+        title:   this.t('epinio.growl.application.appLogs.error.title'),
+        message: this.t('epinio.growl.application.appLogs.error.message'),
       }, { root: true });
     }
   }
@@ -917,8 +915,8 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
   showStagingLog(stageId = this.stage_id) {
     if (!stageId) {
       this.$dispatch('growl/error', {
-        title: 'Something Went Wrong Opening Build Logs!',
-        message: `Can't show build logs for ${ this.meta.name }, no build information is available.`,
+        title:   this.t('epinio.growl.application.buildLogs.noInfo.title'),
+        message: this.t('epinio.growl.application.buildLogs.noInfo.message', { name: this.meta.name }),
       }, { root: true });
 
       return;
@@ -946,8 +944,8 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
     } catch (e) {
       console.log(e);
       this.$dispatch('growl/error', {
-        title: 'Something Went Wrong Opening Build Logs!',
-        message: `Can't open build logs. Please try again or contact your system admin to investigate the issue.`,
+        title:   this.t('epinio.growl.application.buildLogs.error.title'),
+        message: this.t('epinio.growl.application.buildLogs.error.message'),
       }, { root: true });
     }
   }
@@ -1390,8 +1388,8 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
 
   async restart() {
     this.$dispatch('growl/info', {
-      title: 'Attempting to Restart Application!',
-      message: `This can take a few moments, we'll let you know once it's ready.`,
+      title:   this.t('epinio.growl.application.restart.info.title'),
+      message: this.t('epinio.growl.application.restart.info.message'),
     }, { root: true });
 
     try {
@@ -1399,15 +1397,14 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
       await this.forceFetch();
       this.showAppLog();
       this.$dispatch('growl/success', {
-        title: 'Application Restarted!',
-        message: `${ this.meta.name } has been restarted successfully.`,
+        title:   this.t('epinio.growl.application.restart.success.title'),
+        message: this.t('epinio.growl.application.restart.success.message', { name: this.meta.name }),
       }, { root: true });
     } catch (e) {
       console.log(e);
       this.$dispatch('growl/error', {
-        title: 'Something Went Wrong Restarting!',
-        message: `Can't restart the application, the image may be missing,
-        reach out to your system admin to investigate the issue.`,
+        title:   this.t('epinio.growl.application.restart.error.title'),
+        message: this.t('epinio.growl.application.restart.error.message'),
       }, { root: true });
     }
   }
@@ -1423,8 +1420,8 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
     } catch (e) {
       console.log(e);
       this.$dispatch('growl/error', {
-        title: 'Something Went Wrong Downloading Manifest!',
-        message: `Can't download the application manifest. Please try again or contact your system admin to investigate the issue.`,
+        title:   this.t('epinio.growl.application.manifest.error.title'),
+        message: this.t('epinio.growl.application.manifest.error.message'),
       }, { root: true });
       throw e;
     }

--- a/dashboard/pkg/epinio/models/epiniomgmt/epinio.io.management.cluster.js
+++ b/dashboard/pkg/epinio/models/epiniomgmt/epinio.io.management.cluster.js
@@ -44,15 +44,15 @@ export default class EpinioCluster extends Resource {
       this.loggedIn = false;
 
       this.$dispatch('growl/success', {
-        title: 'Logged Out Successfully!',
-        message: 'You have been logged out of Epinio.',
+        title:   this.t('epinio.growl.auth.logout.success.title'),
+        message: this.t('epinio.growl.auth.logout.success.message'),
       }, { root: true });
     } catch (err) {
       console.error(`Failed to log out: ${ err }`);
 
       this.$dispatch('growl/error', {
-        title: 'Something Went Wrong Logging Out!',
-        message: `Can't log out. Please try again or contact your system admin to investigate the issue.`,
+        title:   this.t('epinio.growl.auth.logout.error.title'),
+        message: this.t('epinio.growl.auth.logout.error.message'),
       }, { root: true });
 
       this.metadata = {

--- a/dashboard/pkg/epinio/models/epiniomgmt/epinio.io.management.cluster.js
+++ b/dashboard/pkg/epinio/models/epiniomgmt/epinio.io.management.cluster.js
@@ -42,8 +42,18 @@ export default class EpinioCluster extends Resource {
       await epinioAuth.logout(this.createAuthConfig(EpinioAuthTypes.AGNOSTIC));
 
       this.loggedIn = false;
+
+      this.$dispatch('growl/success', {
+        title: 'Logged Out Successfully!',
+        message: 'You have been logged out of Epinio.',
+      }, { root: true });
     } catch (err) {
       console.error(`Failed to log out: ${ err }`);
+
+      this.$dispatch('growl/error', {
+        title: 'Something Went Wrong Logging Out!',
+        message: `Can't log out. Please try again or contact your system admin to investigate the issue.`,
+      }, { root: true });
 
       this.metadata = {
         state: {

--- a/dashboard/pkg/epinio/models/services.js
+++ b/dashboard/pkg/epinio/models/services.js
@@ -130,9 +130,8 @@ export default class EpinioServiceModel extends EpinioNamespacedResource {
     } catch (e) {
       console.log(e)
       this.$dispatch('growl/error', {
-        title: 'Something Went Wrong Binding the Service',
-        message: `The service most likely wasn't ready yet. Please wait a
-        moment and try again. If the problem persists, please contact support.`,
+        title:   this.t('epinio.growl.service.bind.error.title'),
+        message: this.t('epinio.growl.service.bind.error.message'),
       }, { root: true });
     }
   }
@@ -150,9 +149,8 @@ export default class EpinioServiceModel extends EpinioNamespacedResource {
     } catch (e) {
       console.log(e)
       this.$dispatch('growl/error', {
-        title: 'Something Went Wrong Unbinding the Service',
-        message: `Please wait a moment and try again. If the problem persists,
-        please contact support.`,
+        title:   this.t('epinio.growl.service.unbind.error.title'),
+        message: this.t('epinio.growl.service.unbind.error.message'),
       }, { root: true });
     }
   }


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
Action menu operations backed by modals or model methods often failed silently or only showed inline errors, with no user-facing success or failure notification. This PR adds growl success and error notifications across configuration, service, export, application shell/log, manifest download, deployment view, and logout flows, aligned with the existing Rebuild and Restart notification style.

### Occurred changes and/or fixed issues
ConfigurationModal.vue — success notifications on create/update; error notification on failure (inline errors retained).
ConfigurationDeleteModal.vue — success notification on delete; error notification on failure.
ServiceInstanceModal.vue — success notifications on create/update; error notification on failure.
ServiceDeleteModal.vue — success notification on delete; error notification on failure; fixed app refresh dispatch to use epinio/findAll with EPINIO_TYPES.APP instead of bare findAll.
ExportAppModal.vue — success notification on export; error notification on failure; modal now closes only on successful export; failed browser-side zip fallback throws instead of failing silently; download button disabled on error.
showAppShell() — guard when no running instances; growl error on failure.
showAppLog() — growl error on failure.
showStagingLog() — growl error when no build/stage id is available (replaces console.warn); growl error on open failure.
viewDeploymentInCluster() — growl error when navigation fails.
createManifest() — growl error when manifest download fails.

### Technical notes summary
Notifications use the existing Vuex growl/success, growl/error, and (where applicable) growl/info store actions, consistent with restage() and restart() in applications.js.
Modal components keep existing inline errors banner behavior via epinioExceptionToErrorsArray; growl notifications are added as an additional user-facing layer.
Export modal behavior change: previously the modal closed even when export failed; it now stays open on error so the user can read the failure and retry.
App shell actions now validate that a running instance exists before opening the window manager.
No backend changes required.
### Areas or cases that should be tested
Configuration modals
 Create configuration — success growl appears; list refreshes.
 Edit configuration — success growl appears.
 Delete configuration — success growl appears.
 Force API failure (e.g. duplicate name, permission denied) — inline error banner + error growl; modal stays open.
Service modals
 Create service instance — success growl appears.
 Edit service instance (bind/unbind apps) — success growl appears.
 Delete service instance — success growl appears; bound applications refresh correctly.
 Force delete failure — inline error + error growl.
Application export
 Export application successfully — success growl; modal closes after download.
 Simulate export failure (network error or missing export parts) — error growl; modal stays open; download disabled.
Application action menu (model actions)
 Open App Shell with running instances — shell opens normally.
 Open App Shell with no running instances — error growl; no crash.
 Open App Logs — works normally; error growl on failure.
 Open Build Logs when build info exists — works normally.
 Open Build Logs when no stage/build id — error growl (no silent console warning).
 Download Manifest — success download; error growl on failure.
 View Deployment in cluster — navigates on success; error growl on failure.
Logout
 Log out successfully — success growl.
 Simulate logout failure — error growl.
Regression
 Rebuild and Restart still show their existing info/success/error growls unchanged.
 Application delete (AppDeleteModal) still works as before.

### Areas which could experience regressions
Export modal UX — modal no longer auto-closes on failure; confirm this is desired and retry flow works.
Service delete refresh — dispatch fix from findAll to epinio/findAll may change how quickly bound apps update after service deletion.
App shell with zero instances — new guard may block shell access that previously attempted to open and failed less visibly.
Staging/build logs — apps without build metadata now show an error growl instead of only logging a warning.
Manifest download — errors are now surfaced via growl and re-thrown; callers depending on silent failure may behave differently.
Logout flow — new success notification on an action that previously had no user feedback.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
