### PR TITLE
Add metrics unavailable UI and checks

### DIFF
--- a/dashboard/pkg/epinio/detail/applications.vue
+++ b/dashboard/pkg/epinio/detail/applications.vue
@@ -7,6 +7,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import Application from '../models/applications';
 import { GitUtils } from '@shell/utils/git';
 import { isArray } from '@shell/utils/array';
+import { formatSi } from '@shell/utils/units';
 import { EPINIO_TYPES } from '../types';
 import { epinioExceptionToErrorsArray } from '../utils/errors';
 import Tabs from '../components/application/Tabs.vue';
@@ -121,12 +122,18 @@ const instanceColumns = [
   {
     field: 'millicpus',
     label: 'Mill CPUs',
-    formatter: 'milliCPUs'
+    formatter: (value: unknown, row: { metricsOk?: boolean }) => formatMetricValue(value, row)
   },
   {
     field: 'memoryBytes',
     label: 'RAM',
-    formatter: 'memory'
+    formatter: (value: unknown, row: { metricsOk?: boolean }) => {
+      if (row.metricsOk === false) {
+        return t('epinio.intro.metrics.notAvailableShort');
+      }
+
+      return formatSi(value, { suffix: 'iB', firstSuffix: 'B', increment: 1024 });
+    }
   },
   {
     field: 'restarts',
@@ -209,6 +216,18 @@ const canEditConfig = computed(() => {
   const canGetter = store.getters['epinio/can'];
   return canGetter && (canGetter('configuration_write') || canGetter('configuration'));
 });
+
+const showMetricsUnavailable = computed(() => {
+  return props.value.instances.length > 0 && !props.value.metricsOk;
+});
+
+function formatMetricValue(value: unknown, row: { metricsOk?: boolean }) {
+  if (row.metricsOk === false) {
+    return t('epinio.intro.metrics.notAvailableShort');
+  }
+
+  return value;
+}
 
 
 watchEffect(() => {
@@ -559,7 +578,15 @@ function handleDeleted() {
                   </div>
                 </div>
                 <div class="deployment__origin__row">
+                  <Banner
+                    v-if="showMetricsUnavailable"
+                    color="warning"
+                    class="metrics-unavailable"
+                  >
+                    {{ t('epinio.intro.metrics.notAvailable') }}
+                  </Banner>
                   <div
+                    v-else
                     class="stats-table"
                   >
                     <table class="mt-15">

--- a/dashboard/pkg/epinio/l10n/en-us.yaml
+++ b/dashboard/pkg/epinio/l10n/en-us.yaml
@@ -119,6 +119,8 @@ epinio:
       availability: 'Available node resources: { availableCpu }% cpu, { availableMemory }% memory. '
       link:
         label: Show Metrics in Cluster Explorer
+      notAvailable: Metrics are not enabled. CPU and memory usage cannot be displayed. Install a metrics server in your cluster to enable this feature.
+      notAvailableShort: not available
   tableHeaders:
     namespace: Namespace
   instances:

--- a/dashboard/pkg/epinio/models/applications.js
+++ b/dashboard/pkg/epinio/models/applications.js
@@ -553,6 +553,22 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
     }));
   }
 
+  get metricsOk() {
+    const replicas = this.deployment?.replicas;
+
+    if (!replicas) {
+      return true;
+    }
+
+    const replicaList = Object.values(replicas);
+
+    if (replicaList.length === 0) {
+      return true;
+    }
+
+    return replicaList.every((r) => r.metricsOk);
+  }
+
   get instanceMemory() {
     const stats = this._instanceStats('memoryBytes');
     const opts = {

--- a/dashboard/pkg/epinio/pages/c/_cluster/dashboard.vue
+++ b/dashboard/pkg/epinio/pages/c/_cluster/dashboard.vue
@@ -32,6 +32,7 @@ const t = store.getters['i18n/t'];
 //Variables that can recieve updates
 const version = ref<string>('');
 const showMetricsInfo = ref<boolean>(false);
+const metricsStatus = ref<'unknown' | 'available' | 'unavailable'>('unknown');
 const availableCpu = ref<number>(100);
 const availableMemory = ref<number>(100);
 const sectionContent = ref<Array>([
@@ -188,6 +189,30 @@ const metricsDetails = computed(() => {
   };
 });
 
+const showMetricsUnavailable = computed(() => {
+  if (store.getters['isSingleProduct']) {
+    const allApps = store.getters['epinio/all'](EPINIO_TYPES.APP) as EpinioApplicationResource[];
+
+    return allApps.some((app) => {
+      const replicas = app.deployment?.replicas;
+
+      if (!replicas) {
+        return false;
+      }
+
+      const replicaList = Object.values(replicas);
+
+      if (replicaList.length === 0) {
+        return false;
+      }
+
+      return replicaList.some((r) => !r.metricsOk);
+    });
+  }
+
+  return metricsStatus.value === 'unavailable';
+});
+
 onMounted(async () => {
   generateCards();
   await getVersionHash();
@@ -228,7 +253,13 @@ async function calcAvailableResources() {
 
   const nodeMetricsSchema = store.getters[`epinio/schemaFor`](METRIC.NODE);
 
-  if (nodeMetricsSchema) {
+  if (!nodeMetricsSchema) {
+    metricsStatus.value = 'unavailable';
+
+    return;
+  }
+
+  try {
     const id = store.getters['clusterId'];
 
     const nodeMetrics = await store.dispatch(
@@ -253,6 +284,9 @@ async function calcAvailableResources() {
     availableMemory.value = Math.floor(100 - memory.useful / memory.total * 100);
 
     showMetricsInfo.value = true;
+    metricsStatus.value = 'available';
+  } catch (e) {
+    metricsStatus.value = 'unavailable';
   }
 }
 
@@ -346,7 +380,14 @@ function handleCardDismiss(e: Event, cardType: string) {
       </div>
     </div>
     <Banner
-      v-if="showMetricsInfo"
+      v-if="showMetricsUnavailable"
+      class="metrics"
+      color="warning"
+    >
+      {{ t('epinio.intro.metrics.notAvailable') }}
+    </Banner>
+    <Banner
+      v-else-if="showMetricsInfo"
       class="metrics"
       color="info"
     >


### PR DESCRIPTION


### PR Checklist
- [x] Linting Test is passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
The dashboard and application detail pages display CPU and memory metrics. When a metrics server is not installed, those views showed broken or empty UI with no explanation. This PR detects unavailable metrics and shows a clear warning banner, with graceful fallbacks in the instances table.

### Occurred changes and/or fixed issues
Dashboard (pages/c/_cluster/dashboard.vue)

Track metrics availability via a new metricsStatus state (unknown | available | unavailable).
Mark metrics unavailable when the node metrics schema is missing or the metrics API fetch fails.
Show a warning banner with guidance when metrics are unavailable.
Show the existing “available resources” info banner only when metrics are available.
In Rancher extension mode, also detect unavailable metrics from application replica metricsOk flags.
Application detail (detail/applications.vue)

Show a warning banner instead of the CPU/memory stats table when the app has instances but metrics are unavailable.
Format Mill CPUs and RAM instance columns as “not available” when metricsOk is false.
Application model (models/applications.js)

Add metricsOk getter derived from deployment.replicas — returns true when all replicas report metrics as available.
Localization (l10n/en-us.yaml)

Add epinio.intro.metrics.notAvailable (full banner message).
Add epinio.intro.metrics.notAvailableShort (table cell fallback).
No backend changes; uses existing replica metricsOk data and node metrics API responses.

### Technical notes summary
Dashboard standalone mode: checks for METRIC.NODE schema and fetches /k8s/clusters/{id}/v1/metrics.k8s.io.nodemetrics; failures set metricsStatus to unavailable.
Dashboard Rancher extension mode: scans loaded applications and checks deployment.replicas[].metricsOk because cluster-level metrics may not be directly available the same way.
Application detail: showMetricsUnavailable is true when the app has instances and app.metricsOk is false (any replica missing metrics).
Stats table (min/max/avg CPU and memory) is hidden when metrics are unavailable; instances table still renders with “not available” in metric columns.
metricsOk defaults to true when there are no replicas yet, so apps without deployments do not show a false warning.

### Areas or cases that should be tested
Open Epinio Dashboard — warning banner appears: “Metrics are not enabled…”
Confirm the old broken/empty metrics UI is not shown.
Open an Application detail page with running instances — warning banner appears in place of the stats table.
 Instances tab — Mill CPUs and RAM columns show “not available” instead of broken values.
### Areas which could experience regressions
Dashboard metrics info banner — logic changed from v-if="showMetricsInfo" to v-else-if="showMetricsInfo" behind the unavailable check; confirm the info banner still appears when metrics work.
calcAvailableResources — new early return when schema is missing; verify it does not block other dashboard initialization.
Rancher extension detection — showMetricsUnavailable uses app replica data in single-product mode; false positives/negatives if metricsOk is missing or stale on API response.
Application stats table — hidden entirely when metrics unavailable; users lose min/max/avg view even if partial data existed before.
Instance table formatters — custom formatters replace milliCPUs and memory column formatters; verify display when metrics are available matches previous behavior.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
