### PR TITLE
Support Dockerfile build mode for applications

### DIFF
--- a/dashboard/pkg/epinio/components/application/AppSource.vue
+++ b/dashboard/pkg/epinio/components/application/AppSource.vue
@@ -10,6 +10,7 @@ import { sortBy } from '@shell/utils/sort';
 import { generateZip } from '@shell/utils/download';
 import {
   APPLICATION_SOURCE_TYPE,
+  APPLICATION_BUILD_MODE,
   EpinioApplicationChartResource,
   EpinioInfo,
   EpinioAppSource,
@@ -61,6 +62,8 @@ const fileDialogActive = ref(false);
 // Defaults
 const defaultBuilderImage = ref(props.info?.default_builder_image || DEFAULT_BUILD_PACK); 
 const builderImageValue = ref(props.source?.builderImage?.value || defaultBuilderImage.value);
+const buildMode = ref(props.source?.buildMode || APPLICATION_BUILD_MODE.BUILDPACK);
+const dockerfilePath = ref(props.source?.dockerfilePath || 'Dockerfile');
 
 // Reactive State
 const gitSkipTypeReset = ref(false);
@@ -115,8 +118,20 @@ const appCharts = computed(() =>
 );
 
 const showBuilderImage = computed(() =>
+  [APPLICATION_SOURCE_TYPE.ARCHIVE, APPLICATION_SOURCE_TYPE.FOLDER, APPLICATION_SOURCE_TYPE.GIT_URL, APPLICATION_SOURCE_TYPE.GIT_HUB, APPLICATION_SOURCE_TYPE.GIT_LAB].includes(type.value) &&
+  buildMode.value === APPLICATION_BUILD_MODE.BUILDPACK
+);
+
+const showBuildMode = computed(() =>
   [APPLICATION_SOURCE_TYPE.ARCHIVE, APPLICATION_SOURCE_TYPE.FOLDER, APPLICATION_SOURCE_TYPE.GIT_URL, APPLICATION_SOURCE_TYPE.GIT_HUB, APPLICATION_SOURCE_TYPE.GIT_LAB].includes(type.value)
 );
+
+const showDockerfilePath = computed(() => showBuildMode.value && buildMode.value === APPLICATION_BUILD_MODE.DOCKERFILE);
+
+const buildModes = [
+  { label: t('epinio.applications.steps.source.buildMode.buildpack'), value: APPLICATION_BUILD_MODE.BUILDPACK },
+  { label: t('epinio.applications.steps.source.buildMode.dockerfile'), value: APPLICATION_BUILD_MODE.DOCKERFILE },
+];
 
 const gitSource = computed(() => ({
   type: type.value,
@@ -145,10 +160,16 @@ function validate() {
   switch (type.value) {
     case APPLICATION_SOURCE_TYPE.ARCHIVE:
     case APPLICATION_SOURCE_TYPE.FOLDER:
+      if (buildMode.value === APPLICATION_BUILD_MODE.DOCKERFILE) {
+        return !!archive.tarball && !!dockerfilePath.value;
+      }
       return !!archive.tarball && !!builderImage.value;
     case APPLICATION_SOURCE_TYPE.CONTAINER_URL:
       return !!container.url;
     case APPLICATION_SOURCE_TYPE.GIT_URL:
+      if (buildMode.value === APPLICATION_BUILD_MODE.DOCKERFILE) {
+        return !!gitUrl.url && !!gitUrl.branch && !!gitUrl.validGitUrl && !!dockerfilePath.value;
+      }
       return !!gitUrl.url && !!gitUrl.branch && !!builderImage.value && !!gitUrl.validGitUrl;
     case APPLICATION_SOURCE_TYPE.GIT_HUB:
     case APPLICATION_SOURCE_TYPE.GIT_LAB:
@@ -166,6 +187,8 @@ function update() {
       value: builderImageValue.value,
       default:  builderImageValue.value === defaultBuilderImage.value
     },
+    buildMode: buildMode.value,
+    dockerfilePath: dockerfilePath.value,
     appChart: appChart.value,
     git
   });
@@ -516,6 +539,34 @@ onMounted(() => {
         placeholder="Select an application chart"
         @dropdown-change="(e: CustomEvent) => { appChart = e.detail.value; update(); }"
       />
+
+      <template v-if="showBuildMode">
+        <div class="spacer source">
+          <h4>{{ t('epinio.applications.steps.source.buildMode.label') }}</h4>
+          <trailhand-dropdown
+            style="width: 100%;"
+            :options="buildModes"
+            :value="buildMode"
+            data-testid="epinio_app-source_build-mode"
+            :label="t('epinio.applications.steps.source.buildMode.inputLabel')"
+            @dropdown-change="(e: CustomEvent) => { buildMode = e.detail.value; update(); }"
+          />
+        </div>
+      </template>
+
+      <template v-if="showDockerfilePath">
+        <div class="spacer source">
+          <h4>{{ t('epinio.applications.steps.source.dockerfilePath.label') }}</h4>
+          <trailhand-text-input
+            style="width: 100%;"
+            :value="dockerfilePath"
+            data-testid="epinio_app-source_dockerfile-path"
+            :label="t('epinio.applications.steps.source.dockerfilePath.inputLabel')"
+            :required="true"
+            @text-input-change="(e: CustomEvent) => { dockerfilePath = e.detail.value; update(); }"
+          />
+        </div>
+      </template>
 
       <template v-if="showBuilderImage">
         <div class="spacer source builder-image">

--- a/dashboard/pkg/epinio/l10n/en-us.yaml
+++ b/dashboard/pkg/epinio/l10n/en-us.yaml
@@ -254,6 +254,14 @@ epinio:
             label: Container Image
             inputLabel: Image
             tooltip: Container Image for the app workload
+        buildMode:
+          label: Build Method
+          inputLabel: Build Method
+          buildpack: Buildpack (Paketo)
+          dockerfile: Dockerfile
+        dockerfilePath:
+          label: Dockerfile Path
+          inputLabel: Dockerfile Path
         manifest:
           button: From Manifest
           tooltip: Manifests can provide app configuration from another app

--- a/dashboard/pkg/epinio/models/application-action.js
+++ b/dashboard/pkg/epinio/models/application-action.js
@@ -110,10 +110,14 @@ export default class ApplicationActionResource extends Resource {
     const image = isContainer ? source.container.url : undefined;
     const blobUid = isContainer ? undefined : this.application.buildCache.store?.blobUid;
     const builderImage = isContainer ? undefined : source.builderImage?.value;
+    const buildMode = isContainer ? undefined : source.buildMode;
+    const dockerfilePath = isContainer ? undefined : source.dockerfilePath;
 
     await this.application.waitAsyncBuildPhase({
       blobUid,
       builderImage,
+      buildMode,
+      dockerfilePath,
       image,
       origin: this.createDeployOrigin(source),
       isContainer
@@ -130,10 +134,14 @@ export default class ApplicationActionResource extends Resource {
 
     const blobUid = isContainer ? undefined : this.application.buildCache.store?.blobUid;
     const builderImage = isContainer ? undefined : source.builderImage?.value;
+    const buildMode = isContainer ? undefined : source.buildMode;
+    const dockerfilePath = isContainer ? undefined : source.dockerfilePath;
 
     await this.application.waitAsyncDeployPhase({
       blobUid,
       builderImage,
+      buildMode,
+      dockerfilePath,
       image,
       origin: this.createDeployOrigin(source),
       isContainer

--- a/dashboard/pkg/epinio/models/applications.js
+++ b/dashboard/pkg/epinio/models/applications.js
@@ -763,7 +763,7 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
     return res.blobuid;
   }
 
-  async stage(blobuid, builderImage) {
+  async stage(blobuid, builderImage, buildMode, dockerfilePath) {
     this.trace('Staging Application bits');
 
     const { image, stage } = await this.followLink('stage', {
@@ -775,7 +775,9 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
           namespace: this.meta.namespace
         },
         blobuid,
-        builderimage: builderImage
+        builderimage: builderImage,
+        buildmode:      buildMode,
+        dockerfilepath: dockerfilePath,
       }
     });
 
@@ -1055,14 +1057,14 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
    * Build phase: wait until server leaves staging (async) or finish client-side stage+wait (sync fallback).
    * Container sources skip this step.
    */
-  async waitAsyncBuildPhase({ blobUid, builderImage, image, origin, isContainer }) {
+  async waitAsyncBuildPhase({ blobUid, builderImage, buildMode, dockerfilePath, image, origin, isContainer }) {
     this.trace('Async build phase');
     if (isContainer) {
       return;
     }
-    await this.ensureAsyncDeployStarted({ blobUid, builderImage, image, origin });
+    await this.ensureAsyncDeployStarted({ blobUid, builderImage, buildMode, dockerfilePath, image, origin });
     if (this.buildCache.deployMode === 'sync') {
-      await this.buildSyncOnly(blobUid, builderImage);
+      await this.buildSyncOnly(blobUid, builderImage, buildMode, dockerfilePath);
       return;
     }
     const id = this.buildCache.asyncDeployDeploymentId;
@@ -1082,9 +1084,9 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
   /**
    * Deploy phase: wait for terminal async status or run sync deploy (fallback).
    */
-  async waitAsyncDeployPhase({ blobUid, builderImage, image, origin }) {
+  async waitAsyncDeployPhase({ blobUid, builderImage, buildMode, dockerfilePath, image, origin }) {
     this.trace('Async deploy phase');
-    await this.ensureAsyncDeployStarted({ blobUid, builderImage, image, origin });
+    await this.ensureAsyncDeployStarted({ blobUid, builderImage, buildMode, dockerfilePath, image, origin });
     if (this.buildCache.deployMode === 'sync') {
       await this.deploySyncOnly({ image, origin });
       await this.forceFetch();
@@ -1105,7 +1107,7 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
     await this.forceFetch();
   }
 
-  async ensureAsyncDeployStarted({ blobUid, builderImage, image, origin }) {
+  async ensureAsyncDeployStarted({ blobUid, builderImage, buildMode, dockerfilePath, image, origin }) {
     this.buildCache = this.buildCache || {};
     if (this.buildCache.deployMode === 'sync' || this.buildCache.asyncDeployDeploymentId) {
       return;
@@ -1139,6 +1141,8 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
         },
         blobuid:      blobUid,
         builderimage: builderImage,
+        buildmode:      buildMode,
+        dockerfilepath: dockerfilePath,
         image,
         origin
       }
@@ -1177,9 +1181,9 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
     this.persistAsyncDeploymentId(deploymentId);
   }
 
-  async buildSyncOnly(blobUid, builderImage) {
+  async buildSyncOnly(blobUid, builderImage, buildMode, dockerfilePath) {
     this.trace('Sync build (stage) only');
-    const { image: builtImage, stage } = await this.stage(blobUid, builderImage);
+    const { image: builtImage, stage } = await this.stage(blobUid, builderImage, buildMode, dockerfilePath);
     this.buildCache.stageForSync = { stage, image: builtImage };
     if (stage?.id) {
       this.showStagingLog(stage.id);

--- a/dashboard/pkg/epinio/types.ts
+++ b/dashboard/pkg/epinio/types.ts
@@ -89,6 +89,11 @@ export interface AppSourceGit {
   sourceData: GitAPIData
 }
 
+export enum APPLICATION_BUILD_MODE {
+  BUILDPACK = 'buildpack',
+  DOCKERFILE = 'dockerfile',
+}
+
 export interface AppSourceBuilderImage {
   value: string,
   default: boolean,
@@ -104,6 +109,8 @@ export interface EpinioAppSource {
   git: AppSourceGit,
   gitUrl: AppSourceGitUrl,
   builderImage?: AppSourceBuilderImage,
+  buildMode?: string,
+  dockerfilePath?: string,
   appChart: string,
 }
 


### PR DESCRIPTION


### PR Checklist
- [x] Linting Test is passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
Add an explicit build mode (buildpack or Dockerfile) and Dockerfile path to application source handling. UI: add build mode dropdown and Dockerfile path input with validation and i18n strings. Types: introduce APPLICATION_BUILD_MODE enum and extend EpinioAppSource with buildMode and dockerfilePath. Models: propagate buildMode and dockerfilePath through staging, async build/deploy flows and API payloads so the backend receives the selected build method.
### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
Added APPLICATION_BUILD_MODE enum (buildpack | dockerfile) and extended EpinioAppSource with optional buildMode and dockerfilePath.
AppSource.vue
New Build Method dropdown under Advanced Settings (archive, folder, git URL sources).
New Dockerfile Path input when Dockerfile mode is selected (default: Dockerfile).
Paketo Builder Image section is hidden when build mode is dockerfile.
Validation updated: Dockerfile mode requires archive/git source + Dockerfile path; buildpack mode still requires builder image.
Source change event now includes buildMode and dockerfilePath.
application-action.js — build and deploy pass buildMode and dockerfilePath from source into async build/deploy (skipped for container-image sources).
applications.js — stage(), ensureAsyncDeployStarted(), and sync staging propagate buildmode and dockerfilepath in API payloads (POST .../stage and POST .../deployments).
en-us.yaml — i18n strings for build method and Dockerfile path labels.
Vue ref fix — dropdown/input handlers updated to assign ref.value instead of reassigning the ref (e.g. buildMode.value = ...). Without this, buildmode was sent as undefined and the API defaulted to buildpack.
### Areas or cases that should be tested
Prerequisites

Cluster running epinio + helm-chart branches with Dockerfile build support.
Local UI dev setup or rebuilt extension (see [UI dev docs](https://docs.epinio.io/contribute/ui/extension)).
Sample app with Dockerfile (e.g. epinio-dockerfile-test).
Browser used for local testing: Chrome.

Create application — folder/archive source

Epinio UI → Applications → Create.
Source type: Folder (or Archive).
Upload/select a folder containing Dockerfile, app.py, etc.
Advanced Settings → Build Method → Dockerfile.
Dockerfile Path → Dockerfile.
Confirm Paketo Builder Image is hidden.
Complete wizard → Build should succeed; staging logs show Kaniko, not Paketo.
App reaches Running and route responds.
Create application — buildpack (regression)

Same flow with Build Method → Buildpack (Paketo).
Builder image field visible; default builder pre-filled.
Deploy succeeds via Paketo lifecycle.
Git URL source

Source type: Git URL with a repo containing a Dockerfile.
Build Method → Dockerfile, set Dockerfile path.
Deploy succeeds.
Container image source (regression)

Source type: Container Image.
Build Method / Dockerfile fields should not appear.
Deploy from image URL only; no buildmode in API payload.
Validation

Dockerfile mode without Dockerfile path → wizard blocks progress (invalid source step).
Buildpack mode without uploaded source → blocked as before.
Network verification (optional)

DevTools → Network → POST .../deployments body includes "buildmode":"dockerfile" and "dockerfilepath":"Dockerfile".

### Areas which could experience regressions
Application create wizard — source step validation for archive, folder, git URL, git hub/gitlab.
Async deploy flow — ensureAsyncDeployStarted, build phase polling, sync fallback when async endpoints unavailable.
Sync staging path — buildSyncOnly / stage() still work when buildmode is omitted (buildpack default).
Container-image deploys — must not send buildmode / dockerfilepath.
Builder image UI — show/hide and custom vs default builder when switching build modes.
App chart dropdown — ref assignment fix for appChart (unrelated but touched in same component).
Source type dropdown — ref fix for type switching between archive/folder/git.
Edit/view modes — build mode controls in _EDIT / view (disabled states).
GitHub/GitLab sources — build mode UI visible but Dockerfile path validation not enforced in validate() for these types; verify expected behavior.
Application detail / origin display — builder image may still show for Dockerfile-built apps (display-only; no functional impact on deploy).

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
